### PR TITLE
fix: run api after db

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,8 @@ services:
       context: ./app-api
       dockerfile: ../app-api/Dockerfile.api
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     working_dir: /srv/app
     env_file:
       - .env
@@ -89,6 +90,11 @@ services:
       - type: bind
         source: ./data/database
         target: /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
 networks:
   invariant-explorer-web:

--- a/docker-compose.stable.yml
+++ b/docker-compose.stable.yml
@@ -29,7 +29,8 @@ services:
     image: ghcr.io/invariantlabs-ai/explorer-oss/app-api:${VERSION}
     platform: linux/amd64
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     working_dir: /srv/app
     env_file:
       - .env
@@ -83,6 +84,11 @@ services:
       - type: bind
         source: ./data/database
         target: /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
 networks:
   invariant-explorer-web:

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -55,6 +55,9 @@ services:
     build:
       context: ../app-api
       dockerfile: ../app-api/Dockerfile.api
+    depends_on:
+      database:
+        condition: service_healthy
     working_dir: /srv/app
     env_file:
       - ../.env
@@ -98,6 +101,11 @@ services:
       - type: bind
         source: /tmp/invariant-explorer-test/data/database
         target: /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
 networks:
   invariant-explorer-web-test:


### PR DESCRIPTION
Found a nice trick to only run api when db is ready