### PR TITLE
fix: better error pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 data
+venv
 __pycache__
 .DS_Store

--- a/app-api/routes/dataset.py
+++ b/app-api/routes/dataset.py
@@ -38,7 +38,7 @@ from sqlalchemy import and_, or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
-from sqlalchemy.sql import func
+from sqlalchemy.sql import func, exists
 from util.util import validate_dataset_name
 import os
 
@@ -192,7 +192,7 @@ def list_datasets(kind: DatasetKind, user: Annotated[dict, Depends(UserIdentity)
 @dataset.get("/list/byuser/{user_name}")
 def list_datasets_by_user(request: Request, user_name: str, user: Annotated[dict, Depends(UserIdentity)]):
     with Session(db()) as session:
-        user_exists = session.query(User).filter(User.username == user_name).first()
+        user_exists = session.query(exists().where(User.username == user_name)).scalar()
         if not user_exists:
             raise HTTPException(status_code=404, detail="User not found")
         datasets = session.query(Dataset, User).join(User, User.id == Dataset.user_id).filter(and_(User.username == user_name, Dataset.is_public)).all()

--- a/app-api/routes/dataset.py
+++ b/app-api/routes/dataset.py
@@ -192,6 +192,9 @@ def list_datasets(kind: DatasetKind, user: Annotated[dict, Depends(UserIdentity)
 @dataset.get("/list/byuser/{user_name}")
 def list_datasets_by_user(request: Request, user_name: str, user: Annotated[dict, Depends(UserIdentity)]):
     with Session(db()) as session:
+        user_exists = session.query(User).filter(User.username == user_name).first()
+        if not user_exists:
+            raise HTTPException(status_code=404, detail="User not found")
         datasets = session.query(Dataset, User).join(User, User.id == Dataset.user_id).filter(and_(User.username == user_name, Dataset.is_public)).all()
         return [dataset_to_json(dataset, user) for dataset, user in datasets]
     

--- a/app-ui/src/App.scss
+++ b/app-ui/src/App.scss
@@ -789,6 +789,7 @@ div.empty {
 
   p {
     font-size: 16pt;
+    margin: 2pt;
     opacity: 0.5;
   }
 }

--- a/app-ui/src/Dataset.tsx
+++ b/app-ui/src/Dataset.tsx
@@ -10,6 +10,7 @@ import { useUserInfo } from './UserInfo'
 import { Metadata } from './lib/metadata'
 import { config } from './Config'
 import { useTelemetry } from './telemetry'
+import { NotFound } from './NotFound'
 
 
 interface Query {
@@ -142,11 +143,7 @@ function DatasetView() {
   // if the dataset is not found, display a message
   if (datasetError) {
     if (datasetError.status === 401) {
-      return (
-        <div className='empty'>
-          <h3>It looks like you are not logged in, or your account has no access to this dataset.</h3>
-        </div>
-      );
+      return (<NotFound />);
     }
     return (
       <div className='empty'>

--- a/app-ui/src/Dataset.tsx
+++ b/app-ui/src/Dataset.tsx
@@ -139,11 +139,26 @@ function DatasetView() {
     event.preventDefault()
   }
 
-  // if the dataset is not loaded yet, display a loading message
-  if (!dataset) {
-    return <div className='empty'>
-      <h3>Loading...</h3>
-    </div>
+  // if the dataset is not found, display a message
+  if (datasetError) {
+    if (datasetError.status === 401) {
+      return (
+        <div className='empty'>
+          <h3>It looks like you are not logged in, or your account has no access to this dataset.</h3>
+        </div>
+      );
+    }
+    return (
+      <div className='empty'>
+        <h3>Failed to Load Dataset</h3>
+      </div>
+    );
+  } else if (!dataset) {
+    return (
+      <div className='empty'>
+        <h3>Loading...</h3>
+      </div>
+    );
   }
 
   const filterMetadata = (metadata) => {

--- a/app-ui/src/Dataset.tsx
+++ b/app-ui/src/Dataset.tsx
@@ -10,7 +10,7 @@ import { useUserInfo } from './UserInfo'
 import { Metadata } from './lib/metadata'
 import { config } from './Config'
 import { useTelemetry } from './telemetry'
-import { DatasetNotFound } from './NotFound'
+import { DatasetNotFound, isClientError } from './NotFound'
 
 
 interface Query {
@@ -142,7 +142,7 @@ function DatasetView() {
 
   // if the dataset is not found, display a message
   if (datasetError) {
-    if ([401, 404].includes(datasetError.status)) {
+    if (isClientError(datasetError.status)) {
       return (<DatasetNotFound />);
     }
     return (

--- a/app-ui/src/Dataset.tsx
+++ b/app-ui/src/Dataset.tsx
@@ -10,7 +10,7 @@ import { useUserInfo } from './UserInfo'
 import { Metadata } from './lib/metadata'
 import { config } from './Config'
 import { useTelemetry } from './telemetry'
-import { NotFound } from './NotFound'
+import { DatasetNotFound } from './NotFound'
 
 
 interface Query {
@@ -142,8 +142,8 @@ function DatasetView() {
 
   // if the dataset is not found, display a message
   if (datasetError) {
-    if (datasetError.status === 401) {
-      return (<NotFound />);
+    if ([401, 404].includes(datasetError.status)) {
+      return (<DatasetNotFound />);
     }
     return (
       <div className='empty'>

--- a/app-ui/src/NotFound.tsx
+++ b/app-ui/src/NotFound.tsx
@@ -1,0 +1,14 @@
+export function NotFound() {
+    return <div
+    className='empty'
+    style={{
+      alignItems: 'flex-start', // Keeps text left-aligned
+    }}>
+    <p>
+      Can't view dataset: Dataset does not exist, or you do not have permission to access this dataset.
+    </p>
+    <p>
+      Please log in or contact the owner for access.
+    </p>
+  </div>
+}

--- a/app-ui/src/NotFound.tsx
+++ b/app-ui/src/NotFound.tsx
@@ -1,14 +1,24 @@
-export function NotFound() {
-    return <div
-    className='empty'
-    style={{
-      alignItems: 'flex-start', // Keeps text left-aligned
-    }}>
+export function DatasetNotFound() {
+    return <div className='empty'>
     <p>
-      Can't view dataset: Dataset does not exist, or you do not have permission to access this dataset.
-    </p>
-    <p>
+      Can't view dataset: Dataset does not exist, or you do not have permission to access this dataset. <br />
       Please log in or contact the owner for access.
+    </p>
+  </div>
+}
+export function UserNotFound({ username }: { username: string }) {
+    return (
+      <div className='empty'>
+        <p>
+          Can't find <strong>{username}</strong>: User does not exist.
+        </p>
+      </div>
+    );
+  }
+export function PageNotFound() {
+    return <div className='empty'>
+    <p>
+      Page not found.
     </p>
   </div>
 }

--- a/app-ui/src/NotFound.tsx
+++ b/app-ui/src/NotFound.tsx
@@ -15,6 +15,16 @@ export function UserNotFound({ username }: { username: string }) {
       </div>
     );
   }
+export function TraceNotFound() {
+    return (
+      <div className='empty'>
+        <p>
+        Can't view snippet: Snippet does not exist, or you do not have permission to access this snippet. <br />
+        Please log in or contact the owner for access.
+        </p>
+      </div>
+    );
+  }
 export function PageNotFound() {
     return <div className='empty'>
     <p>

--- a/app-ui/src/NotFound.tsx
+++ b/app-ui/src/NotFound.tsx
@@ -32,3 +32,6 @@ export function PageNotFound() {
     </p>
   </div>
 }
+export function isClientError(statusCode: number): boolean {
+  return statusCode >= 400 && statusCode < 500;
+}

--- a/app-ui/src/RemoteResource.tsx
+++ b/app-ui/src/RemoteResource.tsx
@@ -69,7 +69,7 @@ class RemoteResource {
       })
         .then(response => {
           if (response.status != 200) {
-            throw new Error('Server responded with status ' + response.status)
+            reject(response)
           }
           return response.json()
         })

--- a/app-ui/src/Routes.tsx
+++ b/app-ui/src/Routes.tsx
@@ -123,7 +123,7 @@ export const routes = [
     path: '*',
     label: 'Not Found',
     element: <Layout><div className='empty'>
-      Not Found
+      <h3>Not Found</h3>
     </div></Layout>,
     category: 'hidden'
   }

--- a/app-ui/src/Traces.tsx
+++ b/app-ui/src/Traces.tsx
@@ -19,6 +19,7 @@ import { DeleteSnippetModal } from './lib/snippets';
 import {UserInfo} from './UserInfo';
 import TracePageGuide from './TracePageGuide';
 import { HighlightsNavigator } from './HighlightsNavigator';
+import { NotFound } from './NotFound';
 
 // constant used to combine hierarchy paths
 const pathSeparator = ' > ';
@@ -62,8 +63,11 @@ function useDataset(username: string, datasetname: string): [DatasetData | null,
     sharedFetch(`/api/v1/dataset/byuser/${username}/${datasetname}`)
       .then(data => setDataset(data))
       .catch(e => {
-        alert("Error loading dataset")
+        console.error(e)
         setError(e)
+        if (e.status !== 401) {
+          alert("Error loading traces")
+        }
       })
   }, [username, datasetname])
 
@@ -294,7 +298,9 @@ function useTraces(username: string, datasetname: string): [LightweightTraces | 
       setHierarchyPaths(pathMap)
     }).catch(e => {
       console.error(e)
-      alert("Error loading traces")
+      if (e.status !== 401) {
+        alert("Error loading traces")
+      }
     })
   }
 
@@ -628,8 +634,8 @@ export function Traces() {
     if (datasetLoadingError.status === 401) {
       return (
         <div className='empty'>
-          <h3>It looks like you are not logged in, or your account has no access to this dataset.</h3>
-        </div>
+        <h3>Failed to Load Dataset</h3>
+      </div>
       );
     }
     return (

--- a/app-ui/src/Traces.tsx
+++ b/app-ui/src/Traces.tsx
@@ -19,7 +19,7 @@ import { DeleteSnippetModal } from './lib/snippets';
 import {UserInfo} from './UserInfo';
 import TracePageGuide from './TracePageGuide';
 import { HighlightsNavigator } from './HighlightsNavigator';
-import { NotFound } from './NotFound';
+import { DatasetNotFound } from './NotFound';
 
 // constant used to combine hierarchy paths
 const pathSeparator = ' > ';
@@ -632,7 +632,7 @@ export function Traces() {
   // if the dataset is not found, display a message
   if (datasetLoadingError) {
     if (datasetLoadingError.status === 401) {
-      return (<NotFound />);
+      return (<DatasetNotFound />);
     }
     return (
       <div className='empty'>

--- a/app-ui/src/Traces.tsx
+++ b/app-ui/src/Traces.tsx
@@ -19,7 +19,7 @@ import { DeleteSnippetModal } from './lib/snippets';
 import {UserInfo} from './UserInfo';
 import TracePageGuide from './TracePageGuide';
 import { HighlightsNavigator } from './HighlightsNavigator';
-import { DatasetNotFound, TraceNotFound } from './NotFound';
+import { DatasetNotFound, TraceNotFound, isClientError } from './NotFound';
 
 // constant used to combine hierarchy paths
 const pathSeparator = ' > ';
@@ -64,7 +64,7 @@ function useDataset(username: string, datasetname: string): [DatasetData | null,
       .then(data => setDataset(data))
       .catch(e => {
         setError(e)
-        if (![401, 404].includes(e.status)) {
+        if (!isClientError(e.status)) {
           alert("Error loading dataset")
         }
       })
@@ -297,7 +297,7 @@ function useTraces(username: string, datasetname: string): [LightweightTraces | 
       setHierarchyPaths(pathMap)
     }).catch(e => {
       console.error(e)
-      if (![401, 404].includes(e.status)) {
+      if (!isClientError(e.status)) {
         alert("Error loading traces")
       }
     })
@@ -630,7 +630,7 @@ export function Traces() {
   // error state of this view
   // if the dataset is not found, display a message
   if (datasetLoadingError) {
-    if ([401, 404].includes(datasetLoadingError.status)) {
+    if (isClientError(datasetLoadingError.status)) {
       return (<DatasetNotFound />);
     }
     return (
@@ -1112,7 +1112,7 @@ export function SingleTrace() {
     }).catch(e => {
       console.error(e)
       setError(e)
-      if (![401, 404].includes(e.status)) {
+      if (!isClientError(e.status)) {
         alert("Error loading traces")
       }
     })
@@ -1139,7 +1139,7 @@ export function SingleTrace() {
   // construct header depending on whether we are showing a dataset trace or a snippet trace
   let header = <></>
   if (traceLoadingError){
-    if ([401, 404].includes(traceLoadingError.status)){
+    if (isClientError(traceLoadingError.status)){
       return <TraceNotFound/>
     }
     else {

--- a/app-ui/src/Traces.tsx
+++ b/app-ui/src/Traces.tsx
@@ -55,9 +55,9 @@ export interface DatasetData {
 /**
  * Hook to load the dataset metadata for a given user and dataset name.
  */
-function useDataset(username: string, datasetname: string): [DatasetData | null, string | null] {
+function useDataset(username: string, datasetname: string): [DatasetData | null, Response | null] {
   const [dataset, setDataset] = React.useState(null)
-  const [error, setError] = React.useState(null as string | null);
+  const [error, setError] = React.useState(null as Response | null);
 
   React.useEffect(() => {
     sharedFetch(`/api/v1/dataset/byuser/${username}/${datasetname}`)

--- a/app-ui/src/Traces.tsx
+++ b/app-ui/src/Traces.tsx
@@ -632,11 +632,7 @@ export function Traces() {
   // if the dataset is not found, display a message
   if (datasetLoadingError) {
     if (datasetLoadingError.status === 401) {
-      return (
-        <div className='empty'>
-        <h3>Failed to Load Dataset</h3>
-      </div>
-      );
+      return (<NotFound />);
     }
     return (
       <div className='empty'>

--- a/app-ui/src/Traces.tsx
+++ b/app-ui/src/Traces.tsx
@@ -623,14 +623,26 @@ export function Traces() {
   }, [props.username, props.datasetname])
 
   // error state of this view
+  // if the dataset is not found, display a message
   if (datasetLoadingError) {
-    return <div className='empty'>
-      <h3>Failed to Load Dataset</h3>
-    </div>
+    if (datasetLoadingError.status === 401) {
+      return (
+        <div className='empty'>
+          <h3>It looks like you are not logged in, or your account has no access to this dataset.</h3>
+        </div>
+      );
+    }
+    return (
+      <div className='empty'>
+        <h3>Failed to Load Dataset</h3>
+      </div>
+    );
   } else if (!dataset) {
-    return <div className='empty'>
-      <h3>Loading...</h3>
-    </div>
+    return (
+      <div className='empty'>
+        <h3>Loading...</h3>
+      </div>
+    );
   }
 
   const onAnnotationCreate = (traceIndex: number) => {

--- a/app-ui/src/Traces.tsx
+++ b/app-ui/src/Traces.tsx
@@ -63,10 +63,9 @@ function useDataset(username: string, datasetname: string): [DatasetData | null,
     sharedFetch(`/api/v1/dataset/byuser/${username}/${datasetname}`)
       .then(data => setDataset(data))
       .catch(e => {
-        console.error(e)
         setError(e)
         if (![401, 404].includes(e.status)) {
-          alert("Error loading traces")
+          alert("Error loading dataset")
         }
       })
   }, [username, datasetname])
@@ -298,7 +297,7 @@ function useTraces(username: string, datasetname: string): [LightweightTraces | 
       setHierarchyPaths(pathMap)
     }).catch(e => {
       console.error(e)
-      if (e.status !== 401) {
+      if (![401, 404].includes(e.status)) {
         alert("Error loading traces")
       }
     })
@@ -631,7 +630,7 @@ export function Traces() {
   // error state of this view
   // if the dataset is not found, display a message
   if (datasetLoadingError) {
-    if (datasetLoadingError.status === 401) {
+    if ([401, 404].includes(datasetLoadingError.status)) {
       return (<DatasetNotFound />);
     }
     return (

--- a/app-ui/src/User.tsx
+++ b/app-ui/src/User.tsx
@@ -23,8 +23,6 @@ function User() {
       </div>
     }
   }
-  console.log("datasets")
-  console.log(datasets)
   if (!datasets) {
     return <div className='empty'>
       <p>

--- a/app-ui/src/User.tsx
+++ b/app-ui/src/User.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useLoaderData } from 'react-router-dom'
 import { DatasetLinkList } from './Datasets'
-import { UserNotFound } from './NotFound'
+import { UserNotFound, isClientError } from './NotFound'
 
 /**
  * Component for displaying a user's public datasets, i.e. the user's profile page.
@@ -13,7 +13,7 @@ function User() {
 
   const [datasets, error] = useDatasetList()
   if (error) {
-    if (error.status === 404) {
+    if (isClientError(error.status)) {
       return UserNotFound({ username })
     } else {
       return <div className='empty'>

--- a/tests/test-ui-api/test_dataset.py
+++ b/tests/test-ui-api/test_dataset.py
@@ -801,3 +801,29 @@ async def test_upload_dataset_validate_field_types(context, url, data_abc):
 
     assert response.status == 400
     assert "is_public must be a string representing a boolean" in await response.text()
+
+async def test_list_dataset(context, url, data_abc):
+    """Tests that listing datasets works."""
+    dataset_name = f"some_name-{uuid.uuid4()}"
+    # Upload a dataset.
+    response = await context.request.post(
+        f"{url}/api/v1/dataset/upload",
+        multipart={
+            "name": dataset_name,
+            "file": {
+                "name": dataset_name + ".json",
+                "mimeType": "application/octet-stream",
+                "buffer": data_abc.encode("utf-8"),
+            },
+        },
+    )
+    await expect(response).to_be_ok()
+
+    # List datasets.
+    response = await context.request.get(f"{url}/api/v1/dataset/list")
+    await expect(response).to_be_ok()
+
+    # Cleanup the dataset.
+    dataset_json = await response.json()
+    dataset_id = dataset_json[0]["id"]
+    _ = await context.request.delete(f"{url}/api/v1/dataset/byid/{dataset_id}")


### PR DESCRIPTION
Adding better 404/401 pages for:
* `/u/valid_user/invalid_or_private_dataset/`
* `/u/valid_or_invalid_user/invalid_or_private_dataset/`
* `/u/valid_or_invalid_user/invalid_or_private_dataset/t/0`
* `/u/invalid_user`
* `/trace/invalid_trace`
* `/invalid_route`