### PR TITLE
Fix/close context when done

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
   test:
     name: Build & Test
     timeout-minutes: 30
-    runs-on: gh-large
+    runs-on: ubuntu-latest
 
     steps:
     - name: Stop all running docker containers

--- a/tests/test-ui/test_basic.py
+++ b/tests/test-ui/test_basic.py
@@ -207,7 +207,7 @@ async def test_search(context, url, data_abc_with_trace_metadata, screenshot):
             ("meta:b%asdf", [False, True]),
         ]
 
-        search_input = await page.get_by_placeholder("Search").all()
+        search_input = await retry_fetch(lambda: page.get_by_placeholder("Search").all())
         for query, expected in searches:
             await search_input[0].fill(query)
             await page.wait_for_timeout(1000) # wait for the search to be processed

--- a/tests/test-ui/test_basic.py
+++ b/tests/test-ui/test_basic.py
@@ -380,7 +380,7 @@ async def classes_of_element(element):
 
 async def retry_fetch(fetch_fn, max_time: float = 3.0, time_interval: float = 0.01):
     """
-    The fetch_fn is an Async func that returns a list. We will retry untill it is not empty
+    The fetch_fn is an Async func that returns a list. We will retry until it is not empty
     """
     for _ in range(int(max_time / time_interval)):
         out = await fetch_fn()

--- a/tests/util.py
+++ b/tests/util.py
@@ -35,12 +35,12 @@ async def context(request, slow_mo=250):
         kwargs = request.keywords["playwright"].kwargs
         if "slow_mo" in kwargs:
             slow_mo = kwargs["slow_mo"]
-    playwright = await async_playwright().start()
-    # launch a chrome browser that ignores certificate errors
-    browser = await playwright.firefox.launch(headless=True, slow_mo=slow_mo)
-    context = await browser.new_context(ignore_https_errors=True)
-    return context
-
+    async with async_playwright() as playwright:
+        browser = await playwright.firefox.launch(headless=True, slow_mo=slow_mo)
+        context = await browser.new_context(ignore_https_errors=True)
+        yield context
+        await context.close()
+        await browser.close()
 @pytest.fixture(scope='function')
 async def screenshot(request):
     # setup

--- a/tests/util.py
+++ b/tests/util.py
@@ -29,18 +29,25 @@ def api_server_http_endpoint():
 def name():
     return f"test-{str(uuid4())}"
 
+
 @pytest.fixture
-async def context(request, slow_mo=250):
-    if "playwright" in request.keywords:
-        kwargs = request.keywords["playwright"].kwargs
-        if "slow_mo" in kwargs:
-            slow_mo = kwargs["slow_mo"]
-    async with async_playwright() as playwright:
-        browser = await playwright.firefox.launch(headless=True, slow_mo=slow_mo)
-        context = await browser.new_context(ignore_https_errors=True)
-        yield context
-        await context.close()
-        await browser.close()
+async def playwright(scope="session"):
+    async with async_playwright() as playwright_instance:
+        yield playwright_instance
+
+@pytest.fixture
+async def browser(playwright, scope="session"):
+    browser = await playwright.firefox.launch(headless=True)
+    yield browser
+    await browser.close()
+
+@pytest.fixture
+async def context(browser):
+    context = await browser.new_context(ignore_https_errors=True)
+    yield context
+    await context.close()
+
+
 @pytest.fixture(scope='function')
 async def screenshot(request):
     # setup


### PR DESCRIPTION
Huge memory save on test-runner.
* Now we open playwright and the browser only once. Then we create a context for each test
* Got rid of slowmo. Swapped it with waiting when needed (circa 40s time gain)
* Test now run perfectly on the small runner. Non need for `gh-large`

Before:
<img width="701" alt="Screenshot 2024-12-19 at 15 56 59" src="https://github.com/user-attachments/assets/a6dd71c5-c6fc-462b-8910-f7162e212e8e" />

After (peeks at like 300Mb):
<img width="679" alt="Screenshot 2024-12-19 at 16 11 22" src="https://github.com/user-attachments/assets/f442a449-b36d-4ba3-ab71-584a3bfe0e16" />
