### PR TITLE
Improve the empty dataset view to allow users to upload a file with the traces

### DIFF
--- a/app-api/routes/benchmark.py
+++ b/app-api/routes/benchmark.py
@@ -12,7 +12,6 @@ from fastapi.responses import StreamingResponse
 from models.datasets_and_traces import (Annotation, Dataset, DatasetPolicy,
                                         SavedQueries, SharedLinks, Trace, User,
                                         db)
-from models.importers import import_jsonl
 from models.queries import (dataset_to_json, get_savedqueries, load_annoations,
                             load_dataset, load_trace, query_traces,
                             search_term_mappings, trace_to_exported_json,

--- a/app-ui/src/AnnotationAugmentedTraceView.jsx
+++ b/app-ui/src/AnnotationAugmentedTraceView.jsx
@@ -261,10 +261,14 @@ function TraceViewContent(props) {
   const { datasetname, activeTrace, activeTraceId, highlights, errors, decorator, setEvents } = props
   const EmptyComponent = props.empty || (() => <div className='empty'>No trace selected</div>)
 
+  const onSuccess = () => {
+    window.location.reload();
+  };
+
   // if no trace ID set
   if (activeTraceId === null) {
     return <div className='explorer panel'>
-      <EmptyComponent datasetname={datasetname}/>
+      <EmptyComponent datasetname={datasetname} onSuccess={onSuccess}/>
     </div>
   }
   return <RenderedTrace

--- a/app-ui/src/AnnotationAugmentedTraceView.jsx
+++ b/app-ui/src/AnnotationAugmentedTraceView.jsx
@@ -239,6 +239,7 @@ export function AnnotationAugmentedTraceView(props) {
     <div className='explorer panel traceview'>
       <TraceViewContent
         empty={props.empty}
+        datasetname={props.datasetname}
         activeTrace={activeTrace}
         activeTraceId={activeTraceId}
         highlights={traceHighlights}
@@ -257,13 +258,13 @@ export function AnnotationAugmentedTraceView(props) {
  * Show the rendered trace or an `props.empty` component if no trace is selected.
  */
 function TraceViewContent(props) {
-  const { activeTrace, activeTraceId, highlights, errors, decorator, setEvents } = props
+  const { datasetname, activeTrace, activeTraceId, highlights, errors, decorator, setEvents } = props
   const EmptyComponent = props.empty || (() => <div className='empty'>No trace selected</div>)
 
   // if no trace ID set
   if (activeTraceId === null) {
     return <div className='explorer panel'>
-      <EmptyComponent />
+      <EmptyComponent datasetname={datasetname}/>
     </div>
   }
   return <RenderedTrace

--- a/app-ui/src/App.scss
+++ b/app-ui/src/App.scss
@@ -1977,7 +1977,7 @@ div.empty.instructions {
 
   .options {
     display: flex;
-    margin-top: 30pt;
+    margin-top: 15pt;
     flex-direction: row;
     flex-wrap: wrap;
     align-items: center;
@@ -1988,7 +1988,7 @@ div.empty.instructions {
       border-radius: 5pt;
       border: 1pt solid $border-color;
       margin: 10pt;
-      padding: 30pt 20pt;
+      padding: 15pt 10pt;
       width: 400pt;
       text-align: left;
 
@@ -2001,24 +2001,24 @@ div.empty.instructions {
       h2 {
         border: none;
         font-weight: bold;
-        text-align: center;
-        font-size: 18pt;
+        text-align: left;
+        font-size: 14pt;
       }
 
       p {
         color: $text-color;
         opacity: 0.9;
-        font-size: 14pt;
+        font-size: 12pt;
       }
+    }
 
-      pre {
-        border-radius: 5pt;
-        text-align: left;
-        display: block;
-        overflow-x: auto;
-        padding: 10pt;
-        background-color: #f1f1f1;
-      }
+    input[type=file] {
+      opacity: 0.0;
+      height: 100pt;
+    }
+
+    button { 
+      width: 70%;
     }
   }
 }

--- a/app-ui/src/App.scss
+++ b/app-ui/src/App.scss
@@ -1960,9 +1960,16 @@ div.empty.instructions {
   width: calc(100% - 10pt);
   height: auto;
   margin: auto;
+  margin-top: -45pt !important;
   color: $text-color;
   opacity: 1.0;
   text-align: center;
+
+  .error {
+    color: #ED707B;
+    border-left: 2pt solid #ED707B;
+    padding-left: 3pt;
+  }
 
   h3 {
     opacity: 1.0;
@@ -1973,6 +1980,10 @@ div.empty.instructions {
 
   >p {
     margin: 0pt 30pt;
+  }
+
+  .push-api-option {
+    margin-top: 8pt;
   }
 
   .options {
@@ -1986,9 +1997,10 @@ div.empty.instructions {
     >div {
       background-color: white;
       border-radius: 5pt;
+      height: auto;
       border: 1pt solid $border-color;
       margin: 10pt;
-      padding: 15pt 10pt;
+      padding: 15pt 10pt 10pt 10pt;
       width: 400pt;
       text-align: left;
 

--- a/app-ui/src/Datasets.tsx
+++ b/app-ui/src/Datasets.tsx
@@ -42,7 +42,7 @@ function createDataset(name: string, isPublic: boolean = false) {
 /**
  * Uploads a new dataset to the current user's account.
  */
-function uploadDataset(name: string, file: File, isPublic: boolean = false) {
+export function uploadDataset(name: string, file: File, isPublic: boolean = false) {
   const promise = new Promise((resolve, reject) => {
     const formData = new FormData()
     formData.append('name', name)
@@ -276,7 +276,7 @@ export function UploadDatasetModalContent(props) {
  * 
  * Supports drag and drop, by rendering a 0.0 opacity file <input/> on top of the custom UI.
  */
-function FileUploadMask(props) {
+export function FileUploadMask(props) {
   return <div className='file-upload-mask'>
     <div className='overlay'>
       {props.file ? <span className='selected'><BsFileBinaryFill /> {props.file.name} ({(props.file.size / 1024 / 1024).toFixed(2)} MB)

--- a/app-ui/src/Traces.tsx
+++ b/app-ui/src/Traces.tsx
@@ -745,6 +745,7 @@ export function Traces() {
         onAnnotationCreate={onAnnotationCreate}
         onAnnotationDelete={onAnnotationDelete}
         enableNux={enableNux}
+        datasetname={props.datasetname}
       />}
       {renderNux && <TracePageNUX/>}
     </div>

--- a/app-ui/src/components/EmptyDataset.tsx
+++ b/app-ui/src/components/EmptyDataset.tsx
@@ -20,15 +20,14 @@ export function EmptyDatasetInstructions(props) {
     }
     setLoading(true)
     uploadDataset(datasetname, file).then(() => {
-      // on success, close the modal
-      setLoading(false)
-      props.onSuccess()
-      props.onClose()
-      telemetry.capture('dataset-created', { name: datasetname, from_file: true})
+      setLoading(false);
+      telemetry.capture('dataset-uploaded', { name: datasetname, from_file: true});
+      props.onSuccess();
     }).catch(err => {
-      setLoading(false)
-      setError(err.detail || 'An unknown error occurred, please try again.')
-      telemetry.capture('dataset-create-failed', { name: datasetname, error: err.detail })
+      console.log(err);
+      setLoading(false);
+      setError(err.detail || 'An unknown error occurred, please try again.');
+      telemetry.capture('dataset-upload-failed', { name: datasetname, error: err.detail });
     })
   }
 
@@ -38,10 +37,9 @@ export function EmptyDatasetInstructions(props) {
       <h3>Empty Dataset</h3>
       <p>This dataset does not contain any traces yet.</p>
       <div className="options">
-        <div style={{height: '220pt'}}>
+        <div>
           <h2>Upload a JSON Lines file</h2>
           <p>
-            {" "}
             Before uploading traces make sure they are in the{" "}
             <a
               target="_blank"
@@ -65,7 +63,8 @@ export function EmptyDatasetInstructions(props) {
           >
             {loading ? "Uploading..." : "Upload"}
           </button>
-          <p style={{display: 'none'}}>
+          {error && <span className="error">{error}</span>}
+          <p className="push-api-option">
             <i>
               You can also upload traces using the{" "}
               <a

--- a/tests/test-ui/test_basic.py
+++ b/tests/test-ui/test_basic.py
@@ -145,6 +145,60 @@ async def test_create_delete_dataset(context, url, dataset_name, content, screen
     dataset_mentions = await page.locator(f"text={dataset_name}").all()
     assert len(dataset_mentions) == 0
 
+@pytest.mark.parametrize("content", [lf('data_webarena_with_metadata')])
+async def test_create_empty_dataset_and_then_upload_file(context, url, dataset_name, content, screenshot):
+    """Create an empty dataset and then upload traces for it from the empty dataset view page."""
+    page = await context.new_page()
+    await page.goto(url)
+
+    # create an empty dataset
+    await screenshot(page)
+    await page.click("text=New Dataset")
+    await screenshot(page)
+    dataset_name_input = await page.get_by_placeholder("Dataset Name").all()
+    await dataset_name_input[0].focus()
+    await page.keyboard.type(dataset_name)
+    await screenshot(page)
+    await page.get_by_label("create").click()
+
+    # go to the dataset page
+    await page.goto(url)
+    await page.locator(f"text={dataset_name}").click()
+    await screenshot(page)
+    await page.get_by_role("link", name="All").click()
+    await screenshot(page)
+
+    # upload traces via file upload
+    async with page.expect_file_chooser() as fc_info:
+        await page.get_by_label("file-input").click()
+    file_chooser = await fc_info.value
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        fn = os.path.join(tmpdirname, f"{dataset_name}.jsonl")
+        with open(fn, 'w', encoding="utf-8") as f:
+            f.write(content)
+        await file_chooser.set_files(fn)
+        await screenshot(page)
+        await page.get_by_label("Upload").click()
+
+    # verify that the traces are shown
+    await trace_shown_in_sidebar(page, "Run 1")
+    await trace_shown_in_sidebar(page, "Run 2")
+    await screenshot(page)
+
+    # delete dataset
+    await page.goto(url)
+    await page.locator(f"text={dataset_name}").click()
+    await page.get_by_role("button", name="settings").click()
+    await page.get_by_label("delete").click()
+    await screenshot(page)
+    await page.get_by_label("confirm delete").click()
+    await screenshot(page)
+
+    # we should be back at the home page
+    # check if the dataset is deleted
+    dataset_mentions = await page.locator(f"text={dataset_name}").all()
+    assert len(dataset_mentions) == 0
+
 async def test_reupload_ui(context, url, data_webarena_with_metadata, screenshot):
     async with util.TemporaryExplorerDataset(url, context, data_webarena_with_metadata) as dataset:
         page = await context.new_page()


### PR DESCRIPTION
* Contains changes to the upload API where now we can upload traces to an existing empty dataset. 
* If the user tries to upload traces via file upload to a non empty dataset, we throw a 400. We can relax this requirement as a follow-up. The importer has the starting index set to 0.

Task: https://trello.com/c/gNbkmvWr/156-tweaks-needed-to-the-empty-dataset-view

<img width="1165" alt="Screenshot 2025-01-05 at 16 02 22" src="https://github.com/user-attachments/assets/c6a21828-90a8-4f25-9864-e9fb49c679c1" />
