### PR TITLE
Hide the share button on public datasets not owned by the user.

### DIFF
--- a/app-ui/src/AnnotationAugmentedTraceView.jsx
+++ b/app-ui/src/AnnotationAugmentedTraceView.jsx
@@ -69,6 +69,7 @@ export class Annotations extends RemoteResource {
  * @param {React.Component} props.is_public - whether the trace is public
  * @param {React.Component} props.actions - the actions component (e.g. share, download, open in playground)
  * @param {React.Component} props.empty - the empty component to show if no trace is selected/specified (default: "No trace selected")
+ * @param {boolean} props.isUserOwned - whether the trace is owned by the user
  */
 
 export function AnnotationAugmentedTraceView(props) {
@@ -231,7 +232,7 @@ export function AnnotationAugmentedTraceView(props) {
         {props.actions}
         <div className='vr' />
         {config('sharing') && <button className='inline' onClick={onOpenInPlayground}> <BsTerminal /> Open In Invariant</button>}
-        {config('sharing') && props.onShare && <button className={'inline guide-step-4' + (props.sharingEnabled ? 'primary' : '')} onClick={onShare}>
+        {props.isUserOwned && config('sharing') && props.onShare && <button className={'inline guide-step-4' + (props.sharingEnabled ? 'primary' : '')} onClick={onShare}>
           {!props.sharingEnabled ? <><BsShare /> Share</> : <><BsCheck /> Shared</>}
         </button>}
       </>}

--- a/app-ui/src/Traces.tsx
+++ b/app-ui/src/Traces.tsx
@@ -690,7 +690,7 @@ export function Traces() {
   const isTest = activeTrace?.extra_metadata && typeof activeTrace?.extra_metadata['invariant.num-failures'] === 'number'
   return <div className="panel fullscreen app">
     {/* controls for link sharing */}
-    {sharingEnabled != null && showShareModal && <Modal title="Link Sharing" onClose={() => setShowShareModal(false)} hasWindowControls cancelText="Close">
+    {isUserOwned && sharingEnabled != null && showShareModal && <Modal title="Link Sharing" onClose={() => setShowShareModal(false)} hasWindowControls cancelText="Close">
       <ShareModalContent sharingEnabled={sharingEnabled} setSharingEnabled={setSharingEnabled} traceId={activeTrace?.id} traceName={getFullDisplayName(activeTrace)} />
     </Modal>}
     {/* shown when the user confirms deletion of a trace */}
@@ -746,6 +746,7 @@ export function Traces() {
         onAnnotationDelete={onAnnotationDelete}
         enableNux={enableNux}
         datasetname={props.datasetname}
+        isUserOwned={isUserOwned}
       />}
       {renderNux && <TracePageNUX/>}
     </div>


### PR DESCRIPTION
Task: https://trello.com/c/uKWkWKSc/175-sharing-a-trace-from-a-public-dataset-should-not-have-the-privacy-share-window-show-up