### PR TITLE
Add bounding box highlights for images

### DIFF
--- a/app-ui/src/lib/annotations_parser.ts
+++ b/app-ui/src/lib/annotations_parser.ts
@@ -22,7 +22,7 @@ interface ParsedAnnotationOutput {
 export class AnnotationsParser {
   static parse_annotations(
     annotations,
-    search_highlights: { [key: string]: HighlightData },
+    search_highlights: { [key: string]: HighlightData }
   ): ParsedAnnotationOutput {
     // collect annotations of a character range format (e.g. "messages.0.content:5-9") into mappings
     const highlights: [string, HighlightData][] = search_highlights
@@ -52,30 +52,38 @@ export class AnnotationsParser {
           }
         }
       }
-            
+
       // mappings
       let substr = key.substring(key.indexOf(":"));
-            // Match either a character range or a bounding box
-            if (substr.match(/:\d+-\d+/) || substr.match(/:bbox-\d.\d+,\s*\d.\d+,\s*\d.\d+,\s*\d.\d+/)) {
-                for (let i=0; i<annotations[key].length; i++) {
-                    let annotation = annotations[key][i] // TODO: what do multiple indices here mean{
-                    let highlight: HighlightData = { 
-                        "content": annotation.content,
-                        // allows us to identify the annotation from the highlight
-                        source: annotation.extra_metadata ? annotation.extra_metadata["source"] : "unknown",
-                        "annotationId": key + ":" + i
-                    }
-                    
-                    if (annotation.extra_metadata) {
-                        highlight.extra_metadata = Object.assign({}, annotation.extra_metadata)
-                        // remove source if present
-                        delete highlight.extra_metadata!["source"]
-                    }
-                    
-                    highlights.push([key, highlight])
-                }
-            }
+      // Match either a character range or a bounding box
+      if (
+        substr.match(/:\d+-\d+/) ||
+        substr.match(/:bbox-\d.\d+,\s*\d.\d+,\s*\d.\d+,\s*\d.\d+/)
+      ) {
+        for (let i = 0; i < annotations[key].length; i++) {
+          let annotation = annotations[key][i]; // TODO: what do multiple indices here mean{
+          let highlight: HighlightData = {
+            content: annotation.content,
+            // allows us to identify the annotation from the highlight
+            source: annotation.extra_metadata
+              ? annotation.extra_metadata["source"]
+              : "unknown",
+            annotationId: key + ":" + i,
+          };
+
+          if (annotation.extra_metadata) {
+            highlight.extra_metadata = Object.assign(
+              {},
+              annotation.extra_metadata
+            );
+            // remove source if present
+            delete highlight.extra_metadata!["source"];
+          }
+
+          highlights.push([key, highlight]);
         }
+      }
+    }
 
     // Filter all annotations with "analyzer" as source from all the keys
     // NOTE: Long term might be good to separate analysis results from the other annotations to avoid this kind of filtering logic
@@ -86,7 +94,7 @@ export class AnnotationsParser {
           !(
             annotation.extra_metadata &&
             annotation.extra_metadata["source"] === "analyzer"
-          ),
+          )
       );
       if (new_annotations.length > 0) {
         filtered_annotations[key] = new_annotations;
@@ -111,7 +119,7 @@ export class AnnotationsParser {
         if (annotation.extra_metadata) {
           highlight.extra_metadata = Object.assign(
             {},
-            annotation.extra_metadata,
+            annotation.extra_metadata
           );
           // remove source if present
           delete highlight.extra_metadata!["source"];

--- a/app-ui/src/lib/annotations_parser.ts
+++ b/app-ui/src/lib/annotations_parser.ts
@@ -56,31 +56,26 @@ export class AnnotationsParser {
       // mappings
       let substr = key.substring(key.indexOf(":"));
             // Match either a character range or a bounding box
-      if (substr.match(/:\d+-\d+/) || substr.match(/:bbox-\[\d.\d+,\s*\d.\d+,\s*\d.\d+,\s*\d.\d+\]/)) {
-        for (let i = 0; i < annotations[key].length; i++) {
-          let annotation = annotations[key][i]; // TODO: what do multiple indices here mean{
-          let highlight: HighlightData = {
-            content: annotation.content,
-            // allows us to identify the annotation from the highlight
-            source: annotation.extra_metadata
-              ? annotation.extra_metadata["source"]
-              : "unknown",
-            annotationId: key + ":" + i,
-          };
-
-          if (annotation.extra_metadata) {
-            highlight.extra_metadata = Object.assign(
-              {},
-              annotation.extra_metadata,
-            );
-            // remove source if present
-            delete highlight.extra_metadata!["source"];
-          }
-
-          highlights.push([key, highlight]);
+            if (substr.match(/:\d+-\d+/) || substr.match(/:bbox-\d.\d+,\s*\d.\d+,\s*\d.\d+,\s*\d.\d+/)) {
+                for (let i=0; i<annotations[key].length; i++) {
+                    let annotation = annotations[key][i] // TODO: what do multiple indices here mean{
+                    let highlight: HighlightData = { 
+                        "content": annotation.content,
+                        // allows us to identify the annotation from the highlight
+                        source: annotation.extra_metadata ? annotation.extra_metadata["source"] : "unknown",
+                        "annotationId": key + ":" + i
+                    }
+                    
+                    if (annotation.extra_metadata) {
+                        highlight.extra_metadata = Object.assign({}, annotation.extra_metadata)
+                        // remove source if present
+                        delete highlight.extra_metadata!["source"]
+                    }
+                    
+                    highlights.push([key, highlight])
+                }
+            }
         }
-      }
-    }
 
     // Filter all annotations with "analyzer" as source from all the keys
     // NOTE: Long term might be good to separate analysis results from the other annotations to avoid this kind of filtering logic

--- a/app-ui/src/lib/annotations_parser.ts
+++ b/app-ui/src/lib/annotations_parser.ts
@@ -52,10 +52,11 @@ export class AnnotationsParser {
           }
         }
       }
-
+            
       // mappings
       let substr = key.substring(key.indexOf(":"));
-      if (substr.match(/:\d+-\d+/)) {
+            // Match either a character range or a bounding box
+      if (substr.match(/:\d+-\d+/) || substr.match(/:bbox-\[\d.\d+,\s*\d.\d+,\s*\d.\d+,\s*\d.\d+\]/)) {
         for (let i = 0; i < annotations[key].length; i++) {
           let annotation = annotations[key][i]; // TODO: what do multiple indices here mean{
           let highlight: HighlightData = {

--- a/app-ui/src/lib/traceview/highlights.ts
+++ b/app-ui/src/lib/traceview/highlights.ts
@@ -176,7 +176,7 @@ export class HighlightedJSON {
      * Uses JSON source maps internally, to point from an highlight into the object string. This means the object string
      * must be valid JSON.
      */
-    in_text(object_string: string): Array<Highlight | BoundingBoxHighlight> {
+    in_text(object_string: string): Highlight[] {
         // extract source map pointers
         try {
             let map = null as any
@@ -215,14 +215,15 @@ export class HighlightedJSON {
     }
   }
 
-  /**
-   * Turns a list of highlights into a list of fully separated intervals, where the list of
-   * returned intervals is guaranteed to have no overlaps between each other and the 'content' field contains
-   * the list of item contents that overlap in that interval.
-   */
-  static disjunct(highlights: Highlight[]): GroupedHighlight[] {
-    return disjunct_overlaps(highlights);
-  }
+    /**
+     * Turns a list of highlights into a list of fully separated intervals, where the list of
+     * returned intervals is guaranteed to have no overlaps between each other and the 'content' field contains
+     * the list of item contents that overlap in that interval.
+     */
+    static disjunct(highlights: Highlight[]): GroupedHighlight[] {
+        // Only include highlights that are not bbox highlights
+        return disjunct_overlaps(highlights.filter((a) => !("type" in a && a.type === "bbox")))
+    }
 
     // Returns the list of bounding boxes from the list of highlights
     static bounding_boxes(highlights: Array<BoundingBoxHighlight | Highlight>): BoundingBoxHighlight[] {
@@ -505,7 +506,7 @@ function highlightsToMap(
 
         if (firstSegment.includes('bbox-')) {
             // Split the `key` string of the form {...}:bbox-[F,F,F,F] into an array of floats
-            const bbox = key.split('bbox-[')[1].split(',').map(parseFloat)
+            const bbox = key.split('bbox-')[1].split(',').map(parseFloat)
             const bbox_key = firstSegment.split(':')[0]
             bboxHighlights.push({ key: bbox_key, x1: bbox[0], y1: bbox[1], x2: bbox[2], y2: bbox[3], content: value })
             continue

--- a/app-ui/src/lib/traceview/highlights.ts
+++ b/app-ui/src/lib/traceview/highlights.ts
@@ -28,11 +28,11 @@ export interface Highlight extends HighlightData {
 }
 
 export interface BoundingBoxHighlight extends HighlightData {
-    x1: number
-    y1: number
-    x2: number
-    y2: number
-    content: any
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  content: any;
 }
 
 /** Like a regular highlight, but stores a list of highlights per range. */
@@ -119,7 +119,7 @@ export class HighlightedJSON {
 
       if (current.$highlights) {
         highlights.push(
-          ...current.$highlights.map((a: any) => [current_address, a]),
+          ...current.$highlights.map((a: any) => [current_address, a])
         );
       }
       for (let key in current) {
@@ -165,32 +165,32 @@ export class HighlightedJSON {
       return EMPTY_ANNOTATIONS;
     }
 
-        let highlightsMap = highlightsToMap(mappings)
-        return new HighlightedJSON(highlightsMap)
-    }
+    let highlightsMap = highlightsToMap(mappings);
+    return new HighlightedJSON(highlightsMap);
+  }
 
-    /**
-     * Returns the highlights referenced by this highlight tree, as a list of {start, end, content} objects
-     * relative to the provided object string representation (e.g. JSON representation of the highlighted object).
-     * 
-     * Uses JSON source maps internally, to point from an highlight into the object string. This means the object string
-     * must be valid JSON.
-     */
-    in_text(object_string: string): Highlight[] {
-        // extract source map pointers
-        try {
-            let map = null as any
-            try {
-                // try to parse source map
-                map = jsonMap.parse(object_string)
-            } catch (e) {
-                // if parsing fails, assume it's a string and try again
-                map = {
-                    pointers: {
-                        "": { value: { pos: 0 }, valueEnd: { pos: object_string.length } }
-                    }
-                }
-            }
+  /**
+   * Returns the highlights referenced by this highlight tree, as a list of {start, end, content} objects
+   * relative to the provided object string representation (e.g. JSON representation of the highlighted object).
+   *
+   * Uses JSON source maps internally, to point from an highlight into the object string. This means the object string
+   * must be valid JSON.
+   */
+  in_text(object_string: string): Highlight[] {
+    // extract source map pointers
+    try {
+      let map = null as any;
+      try {
+        // try to parse source map
+        map = jsonMap.parse(object_string);
+      } catch (e) {
+        // if parsing fails, assume it's a string and try again
+        map = {
+          pointers: {
+            "": { value: { pos: 0 }, valueEnd: { pos: object_string.length } },
+          },
+        };
+      }
 
       const pointers: { start: number; end: number; content: string }[] = [];
       for (const key in map.pointers) {
@@ -215,24 +215,30 @@ export class HighlightedJSON {
     }
   }
 
-    /**
-     * Turns a list of highlights into a list of fully separated intervals, where the list of
-     * returned intervals is guaranteed to have no overlaps between each other and the 'content' field contains
-     * the list of item contents that overlap in that interval.
-     */
-    static disjunct(highlights: Highlight[]): GroupedHighlight[] {
-        // Only include highlights that are not bbox highlights
-        return disjunct_overlaps(highlights.filter((a) => !("type" in a && a.type === "bbox")))
-    }
+  /**
+   * Turns a list of highlights into a list of fully separated intervals, where the list of
+   * returned intervals is guaranteed to have no overlaps between each other and the 'content' field contains
+   * the list of item contents that overlap in that interval.
+   */
+  static disjunct(highlights: Highlight[]): GroupedHighlight[] {
+    // Only include highlights that are not bbox highlights
+    return disjunct_overlaps(
+      highlights.filter((a) => !("type" in a && a.type === "bbox"))
+    );
+  }
 
-    // Returns the list of bounding boxes from the list of highlights
-    static bounding_boxes(highlights: Array<BoundingBoxHighlight | Highlight>): BoundingBoxHighlight[] {
-        return highlights.filter((a): a is BoundingBoxHighlight => a.type === "bbox")
-    }
+  // Returns the list of bounding boxes from the list of highlights
+  static bounding_boxes(
+    highlights: Array<BoundingBoxHighlight | Highlight>
+  ): BoundingBoxHighlight[] {
+    return highlights.filter(
+      (a): a is BoundingBoxHighlight => a.type === "bbox"
+    );
+  }
 
   static by_lines(
     disjunct_highlights: Highlight[],
-    text: string,
+    text: string
   ): GroupedHighlight[][] {
     let result: GroupedHighlight[][] = [[]];
     let queue: GroupedHighlight[] = disjunct_highlights.map((a) => ({
@@ -314,7 +320,7 @@ export const EMPTY_ANNOTATIONS = new EmptyHighlights();
  *
  */
 function disjunct_overlaps(
-  items: { start: number; end: number; content: any }[],
+  items: { start: number; end: number; content: any }[]
 ): GroupedHighlight[] {
   // create interval tree for efficient interval queries
   const tree = new IntervalTree();
@@ -323,18 +329,18 @@ function disjunct_overlaps(
   function len_overlap(range1: [number, number], range2: [number, number]) {
     return Math.max(
       0,
-      Math.min(range1[1], range2[1]) - Math.max(range1[0], range2[0]),
+      Math.min(range1[1], range2[1]) - Math.max(range1[0], range2[0])
     );
   }
 
   // collects all interval boundaries
   let boundaries = [0, Infinity];
 
-    for (const item of items) {
-        tree.insert([item.start, item.end], item)
-        boundaries.push(item.start)
-        boundaries.push(item.end)
-    }
+  for (const item of items) {
+    tree.insert([item.start, item.end], item);
+    boundaries.push(item.start);
+    boundaries.push(item.end);
+  }
 
   // make boundaries unique
   boundaries = Array.from(new Set(boundaries));
@@ -368,7 +374,7 @@ function disjunct_overlaps(
  * of format { 0: { tool_calls: { 0: { function: { arguments: [ { start, end, content } ] } } } } }
  */
 function sourceRangesToMap(
-  ranges: { start: number; end: number; content: string }[],
+  ranges: { start: number; end: number; content: string }[]
 ): Record<string, any> {
   const map: Record<string, any> = {};
 
@@ -428,7 +434,7 @@ function sourceRangesToMap(
 function to_text_offsets(
   highlightMap: any,
   sourceRangeMap: any,
-  located_highlights: any[] = [],
+  located_highlights: any[] = []
 ): Highlight[] {
   for (let key of Object.keys(highlightMap)) {
     if (key === "$highlights") {
@@ -454,25 +460,25 @@ function to_text_offsets(
       continue;
     }
 
-        if (key === "$bbox-highlights") {
-            highlightMap[key].forEach((a: any) => {
-                located_highlights.push({
-                    "x1": a["x1"],
-                    "y1": a["y1"],
-                    "x2": a["x2"],
-                    "y2": a["y2"],
-                    "content": a["content"],
-                    "type": "bbox"
-                })
-            })
-            continue;
-        }
+    if (key === "$bbox-highlights") {
+      highlightMap[key].forEach((a: any) => {
+        located_highlights.push({
+          x1: a["x1"],
+          y1: a["y1"],
+          x2: a["x2"],
+          y2: a["y2"],
+          content: a["content"],
+          type: "bbox",
+        });
+      });
+      continue;
+    }
 
     if (sourceRangeMap[key]) {
       to_text_offsets(
         highlightMap[key],
         sourceRangeMap[key],
-        located_highlights,
+        located_highlights
       );
     } else {
       // console.log("key", key, "not found in", sourceRangeMap)
@@ -486,88 +492,122 @@ function to_text_offsets(
 // this makes highlights easier to work with in the UI, as they are grouped by key, index, and prop
 function highlightsToMap(
   highlights: Record<string, any> | [string, any][],
-  prefix = "",
+  prefix = ""
 ): HighlightMap {
   // convert highlights to a list of entries if necessary
   if (!Array.isArray(highlights)) {
     highlights = Object.entries(highlights);
   }
 
-    const map: HighlightMap = { $highlights: [] }
-    const highlightsPerKey: Record<string, Record<string, any>> = {}
-    const directHighlights: { key: string, start: number | null, end: number | null, content: any }[] = []
-    const bboxHighlights: { key: string, x1: number | null, y1: number | null, x2: number | null, y2: number | null, content: any }[] = []
+  const map: HighlightMap = { $highlights: [] };
+  const highlightsPerKey: Record<string, Record<string, any>> = {};
+  const directHighlights: {
+    key: string;
+    start: number | null;
+    end: number | null;
+    content: any;
+  }[] = [];
+  const bboxHighlights: {
+    key: string;
+    x1: number | null;
+    y1: number | null;
+    x2: number | null;
+    y2: number | null;
+    content: any;
+  }[] = [];
 
-    for (const [key, value] of highlights as [string,any][]) {
-        // group keys by first segment (if it is not already a range), then recurse late
-        const parts = key.split('.')
-        const firstSegment = parts[0]
-        const rest = parts.slice(1).join('.')
+  for (const [key, value] of highlights as [string, any][]) {
+    // group keys by first segment (if it is not already a range), then recurse late
+    const parts = key.split(".");
+    const firstSegment = parts[0];
+    const rest = parts.slice(1).join(".");
 
-        if (firstSegment.includes('bbox-')) {
-            // Split the `key` string of the form {...}:bbox-[F,F,F,F] into an array of floats
-            const bbox = key.split('bbox-')[1].split(',').map(parseFloat)
-            const bbox_key = firstSegment.split(':')[0]
-            bboxHighlights.push({ key: bbox_key, x1: bbox[0], y1: bbox[1], x2: bbox[2], y2: bbox[3], content: value })
-            continue
-        }
-
-        if (firstSegment.includes(':')) {
-            const [last_prop, range] = firstSegment.split(':')
-            let [start, end] = range.split('-')
-            let parsedStart = parseInt(start)
-            let parsedEnd = parseFloat(end)
-            if (isNaN(parsedStart) || isNaN(parsedEnd)) {
-                throw new Error(`Failed to parse range ${range} in key ${prefix + key}`)
-            }
-            directHighlights.push({ key: last_prop, start: parsedStart, end: parsedEnd, content: value })
-        } else if (rest.length === 0) {
-            directHighlights.push({ key: firstSegment, start: null, end: null, content: value })
-        } else {
-            if (!highlightsPerKey[firstSegment]) {
-                highlightsPerKey[firstSegment] = []
-            }
-            highlightsPerKey[firstSegment].push([rest, value])
-        }
+    if (firstSegment.includes("bbox-")) {
+      // Split the `key` string of the form {...}:bbox-[F,F,F,F] into an array of floats
+      const bbox = key.split("bbox-")[1].split(",").map(parseFloat);
+      const bbox_key = firstSegment.split(":")[0];
+      bboxHighlights.push({
+        key: bbox_key,
+        x1: bbox[0],
+        y1: bbox[1],
+        x2: bbox[2],
+        y2: bbox[3],
+        content: value,
+      });
+      continue;
     }
+
+    if (firstSegment.includes(":")) {
+      const [last_prop, range] = firstSegment.split(":");
+      let [start, end] = range.split("-");
+      let parsedStart = parseInt(start);
+      let parsedEnd = parseFloat(end);
+      if (isNaN(parsedStart) || isNaN(parsedEnd)) {
+        throw new Error(
+          `Failed to parse range ${range} in key ${prefix + key}`
+        );
+      }
+      directHighlights.push({
+        key: last_prop,
+        start: parsedStart,
+        end: parsedEnd,
+        content: value,
+      });
+    } else if (rest.length === 0) {
+      directHighlights.push({
+        key: firstSegment,
+        start: null,
+        end: null,
+        content: value,
+      });
+    } else {
+      if (!highlightsPerKey[firstSegment]) {
+        highlightsPerKey[firstSegment] = [];
+      }
+      highlightsPerKey[firstSegment].push([rest, value]);
+    }
+  }
 
   for (const key in highlightsPerKey) {
     try {
       map[key] = highlightsToMap(highlightsPerKey[key], prefix + key + ".");
     } catch (e: any) {
       throw new Error(
-        `Failed to parse highlights for key ${prefix + key}: ${e.message}`,
+        `Failed to parse highlights for key ${prefix + key}: ${e.message}`
       );
     }
   }
 
-    for (const highlight of directHighlights) {
-        if (!map[highlight.key]) {
-            map[highlight.key] = {}
-        }
-        if (!map[highlight.key]["$highlights"]) {
-            map[highlight.key]["$highlights"] = []
-        }
-        map[highlight.key]["$highlights"].push({ start: highlight.start, end: highlight.end, content: highlight.content })
+  for (const highlight of directHighlights) {
+    if (!map[highlight.key]) {
+      map[highlight.key] = {};
     }
-    
-    for (const bboxHighlight of bboxHighlights) {
+    if (!map[highlight.key]["$highlights"]) {
+      map[highlight.key]["$highlights"] = [];
+    }
+    map[highlight.key]["$highlights"].push({
+      start: highlight.start,
+      end: highlight.end,
+      content: highlight.content,
+    });
+  }
 
-        if (!map[bboxHighlight.key]) {
-            map[bboxHighlight.key] = {}
-        }
-
-        if (!map[bboxHighlight.key]["$bbox-highlights"]) {
-            map[bboxHighlight.key]["$bbox-highlights"] = []
-        }
-        map[bboxHighlight.key]["$bbox-highlights"].push({ 
-            x1: bboxHighlight.x1, 
-            y1: bboxHighlight.y1, 
-            x2: bboxHighlight.x2, 
-            y2: bboxHighlight.y2, 
-            content: bboxHighlight.content 
-        })
+  for (const bboxHighlight of bboxHighlights) {
+    if (!map[bboxHighlight.key]) {
+      map[bboxHighlight.key] = {};
     }
 
-    return map
+    if (!map[bboxHighlight.key]["$bbox-highlights"]) {
+      map[bboxHighlight.key]["$bbox-highlights"] = [];
+    }
+    map[bboxHighlight.key]["$bbox-highlights"].push({
+      x1: bboxHighlight.x1,
+      y1: bboxHighlight.y1,
+      x2: bboxHighlight.x2,
+      y2: bboxHighlight.y2,
+      content: bboxHighlight.content,
+    });
+  }
+
+  return map;
 }

--- a/app-ui/src/lib/traceview/plugins/image-viewer.scss
+++ b/app-ui/src/lib/traceview/plugins/image-viewer.scss
@@ -52,3 +52,21 @@ span.image-wrapper {
   stroke-linecap: "round";
   stroke-linejoin: "round";
 }
+
+.bounding-box {
+    box-sizing: border-box;
+    pointer-events: none;
+    border-radius: 2px;
+    border-style: solid;
+    border-color: rgb(88 85 255);
+
+    &.test-assertion-passed {
+        background-color: #0f9d0f2d;
+        border-color: #0f9d0f;
+    }
+
+    &.annotated {
+        background-color: #ff00002d;
+        border-color: #ff0000;
+    }
+}

--- a/app-ui/src/lib/traceview/plugins/image-viewer.scss
+++ b/app-ui/src/lib/traceview/plugins/image-viewer.scss
@@ -65,8 +65,9 @@ span.image-wrapper {
         border-color: #0f9d0f;
     }
 
-    &.annotated {
-        background-color: #ff00002d;
-        border-color: #ff0000;
+    // Failed assertion
+    &.test-assertion {
+        background-color: #ba29292d;
+        border: 1pt solid #BA2929;
     }
 }

--- a/app-ui/src/lib/traceview/plugins/image-viewer.tsx
+++ b/app-ui/src/lib/traceview/plugins/image-viewer.tsx
@@ -106,46 +106,49 @@ class ImageViewer extends React.Component<
         await cache.put(url, responseClone);
       }
 
-      const blob = await response.blob();
-      const imageUrl = URL.createObjectURL(blob);
-      this.setState({ imageUrl });
-    } catch (error) {
-      console.error("Error fetching image:", error);
+            const blob = await response.blob();
+            const imageUrl = URL.createObjectURL(blob);
+            this.setState({ imageUrl });
+        } catch (error) {
+            console.error("Error fetching image:", error);
+        }
     }
-  }
 
-    addBoundingBox(x1, y1, x2, y2, index, borderSize = 1, paddingPx = 0) {
+    /**
+     * Create a bounding box using the coordinates given and the content of the annotation.
+     * The `content` and `state` are used to determine the key of the bounding box.
+     * `content` also determines the class of the bounding box (like regular annotations).
+     * The `borderSize` and `paddingPx` are used to adjust the size of the bounding box.
+     */
+    addBoundingBox(x1, y1, x2, y2, content, index, borderWidth = 1, padding = 0) {
+        
         // Adjust coordinates to add padding
-        const adjustedX1 = Math.min(1, Math.max(0, x1 - paddingPx / 100));
-        const adjustedY1 = Math.min(1, Math.max(0, y1 - paddingPx / 100)); 
-        const adjustedX2 = Math.min(1, Math.max(0, x2 + paddingPx / 100));
-        const adjustedY2 = Math.min(1, Math.max(0, y2 + paddingPx / 100));
+        const adjustedX1 = Math.min(1, Math.max(0, x1 - padding / 100));
+        const adjustedY1 = Math.min(1, Math.max(0, y1 - padding / 100)); 
+        const adjustedX2 = Math.min(1, Math.max(0, x2 + padding / 100));
+        const adjustedY2 = Math.min(1, Math.max(0, y2 + padding / 100));
     
         // Calculate new dimensions and position
         const newLeft = adjustedX1 * 100;
         const newTop = adjustedY1 * 100;
         const newWidth = (adjustedX2 - adjustedX1) * 100;
         const newHeight = (adjustedY2 - adjustedY1) * 100;
-    
+        
         return (
             <div
-                key={`bounding-box-${index}`}
-                className="bounding-box"
+                key={`${x1}-${y1}-${x2}-${y2}-${index}`} // Ensure unique key for each bounding box
+                className={`bounding-box ${content?.source}`}
                 style={{
                     position: 'absolute',
                     top: `${newTop + 0.01}%`,
                     left: `${newLeft}%`,
                     width: `${newWidth}%`,
                     height: `${newHeight}%`,
-                    border: `${borderSize}px solid rgb(88 85 255)`,
-                    boxSizing: 'border-box',
-                    pointerEvents: 'none',
-                    borderRadius: '2px'
+                    borderWidth: `${borderWidth}px`,
                 }}
             />
         );
     }
-
 
     /**
      * Get annotations for image and update the higlights for it by either:
@@ -156,40 +159,27 @@ class ImageViewer extends React.Component<
     updateHighlights() {
         let highlights_in_text = this.props.highlights.in_text(JSON.stringify(this.props.content, null, 2))
         let bounding_boxes_data = HighlightedJSON.bounding_boxes(highlights_in_text)
-
         highlights_in_text = HighlightedJSON.disjunct(highlights_in_text)
         let highlights_per_line = HighlightedJSON.by_lines(highlights_in_text, '"' + this.props.content + '"');
         let elements: React.ReactNode[] = [];
 
-        let bounding_boxes = bounding_boxes_data.map(({ x1, y1, x2, y2 }, index) => this.addBoundingBox(x1, y1, x2, y2, index, 1, 0.25));
-
-    // Loop over the highlighted structure
-    let highligthed_found = false;
-    for (const highlights of highlights_per_line) {
-      let image: React.ReactNode[] = [];
-      for (const interval of highlights) {
-        if (interval.content !== null) {
-          let className =
-            "annotated" +
-            " " +
-            interval.content
-              .filter((c) => c["source"])
-              .map((c) => "source-" + c["source"])
-              .join(" ");
-          const tooltip = interval.content
-            .map((c) =>
-              truncate("[" + c["source"] + "]" + " " + c["content"], 100),
-            )
-            .join("\n");
+        // Loop over the highlighted structure
+        let highligthed_found = false;
+        for (const highlights of highlights_per_line) {
+            let image: React.ReactNode[] = [];
+            for (const interval of highlights) {
+                if (interval.content !== null) {
+                    let className = 'annotated' + ' ' + interval.content.filter(c => c['source']).map(c => "source-" + c['source']).join(" ");
+                    const tooltip = interval.content.map(c => truncate('[' + c['source'] + ']' + ' ' + c['content'], 100)).join("\n");
 
                     // We assume that we will have exactly one highlight and that this is for the image,
                     // so only push a new line if find a highlight AND it is the first highlight.
                     if (this.state.imageUrl && !highligthed_found) { 
                         image.push(
                             <span key={(elements.length) + '-' + (image.length) + "-" + (interval.start) + "-" + (interval.end)} className={`image-wrapper ${className}`} data-tooltip-id={'highlight-tooltip'} data-tooltip-content={tooltip}>
-                            <div className="image-container" style={{ position: 'relative' }}>
+                            <div className="image-container" style={{ position: 'relative', display: 'flex' }}>
                                 <img src={this.state.imageUrl} className={`trace-image ${className} ${this.state.isModalOpen ? 'full-size' : ''}`} />
-                                {bounding_boxes}
+                                {bounding_boxes_data.map(({ x1, y1, x2, y2, content }, index) => this.addBoundingBox(x1, y1, x2, y2, content, index, 1, 0.25))}
                             </div>
                         </span>
                     );
@@ -199,10 +189,11 @@ class ImageViewer extends React.Component<
             }
             
             // We still need to render the image if we do not have annotattions
+            // We also add any potential bounding boxes
             if (!highligthed_found) {
                 image.push(<span key={'line-' + elements.length} className='image-wrapper unannotated'>
                     {<img src={this.state.imageUrl || ''} className={`trace-image unannotated`} />}
-                    {bounding_boxes}
+                    {bounding_boxes_data.map(({ x1, y1, x2, y2, content }, index) => this.addBoundingBox(x1, y1, x2, y2, content, index, 1, 0.25))}
                 </span>);
             }
             
@@ -218,6 +209,7 @@ class ImageViewer extends React.Component<
         if (this.state.isModalOpen) {
                 elements.push(
                 <div
+                    key='image-full-screen'
                     className='image-full-screen'
                     onClick={() => this.setState({ isModalOpen: false })}
                 >
@@ -227,12 +219,12 @@ class ImageViewer extends React.Component<
                             alt="Image in the trace fullscreen"
                             className='image-full-screen-opened'
                         />
-                        {bounding_boxes}
+                        {bounding_boxes_data.map(({ x1, y1, x2, y2, content }, index) => this.addBoundingBox(x1, y1, x2, y2, content, index, 1.75, 0.25))}
                     </div>
                 </div>
             );
         }
-        
+
         // Update the nodes for render method
         return elements
     }

--- a/app-ui/src/lib/traceview/plugins/image-viewer.tsx
+++ b/app-ui/src/lib/traceview/plugins/image-viewer.tsx
@@ -5,6 +5,7 @@ import { HighlightedJSON } from "../highlights";
 import { truncate } from "../utils";
 import "./image-viewer.scss";
 
+
 // component properties of the code-highlighter plugin
 interface ImageViewerProps {
   content: string;
@@ -136,11 +137,11 @@ class ImageViewer extends React.Component<
         
         return (
             <div
-                key={`${x1}-${y1}-${x2}-${y2}-${index}`} // Ensure unique key for each bounding box
+                key={`bbox-${x1}-${y1}-${x2}-${y2}-${index}`}
                 className={`bounding-box ${content?.source}`}
                 style={{
                     position: 'absolute',
-                    top: `${newTop + 0.01}%`,
+                    top: `${newTop}%`,
                     left: `${newLeft}%`,
                     width: `${newWidth}%`,
                     height: `${newHeight}%`,


### PR DESCRIPTION
Adds bounding box highlights to images:
![image](https://github.com/user-attachments/assets/48900475-aa86-4f48-860d-f4a717ac9c2a)
The example uses the InvariantImage OCR functionality (only function that produces bboxes at the moment) to find all instances of `invariant` in the image. 

Currently:
- The colour of a bbox defaults to 'invariant purple' when no source (i.e., test pass/fail details) is provided in the annotation, and is otherwise green/red depending on the source.
- The bboxes have no tool tips.
- Are shown when the image is fullscreen as well.
- The image the bboxes are on is still highlighted seperately. This is to show the result of other assertions that may not produce bboxes.

Please see related PR: https://github.com/invariantlabs-ai/invariant/pull/37