### PR TITLE
Fix updown feedback button

### DIFF
--- a/app-ui/src/App.scss
+++ b/app-ui/src/App.scss
@@ -1409,17 +1409,26 @@ button.share {
   height: 31pt;
   background-color: transparent;
   position: absolute;
-  left: 20pt;
+  left: 50pt;
   top: 0pt;
+}
+
+// adjust thumbs position for json table lines
+.json .thumbs::before {
+  width: 240pt;
+  background-color: transparent;
+  left: 50qb;
+}
+
+.json .thumbs {
+  left: -233pt;
 }
 
 .traceview span.line .selectable:hover .thumbs {
   display: inline-block;
   opacity: 0.5;
 }
-.json .thumbs {
-  left: -183pt;
-}
+
 .thumbs {
   position: absolute;
   top: 8pt;

--- a/app-ui/src/App.scss
+++ b/app-ui/src/App.scss
@@ -1417,7 +1417,9 @@ button.share {
   display: inline-block;
   opacity: 0.5;
 }
-
+.json .thumbs {
+  left: -183pt;
+}
 .thumbs {
   position: absolute;
   top: 8pt;

--- a/app-ui/src/Layout.tsx
+++ b/app-ui/src/Layout.tsx
@@ -315,9 +315,11 @@ function Layout(props: {
                       Documentation
                     </a>
                   </li>
-                  <li>
-                    <a href="/logout">Log Out</a>
-                  </li>
+                  {config("instance_name") != "local" && (
+                    <li>
+                      <a href="/logout">Log Out</a>
+                    </li>
+                  )}
                 </ul>
               </div>
             </>

--- a/app-ui/src/lib/traceview/TraceView.scss
+++ b/app-ui/src/lib/traceview/TraceView.scss
@@ -734,8 +734,8 @@ table.json {
   }
 
   tr td:first-child {
-    min-width: 100pt;
-    max-width: 100pt;
+    min-width: 150pt;
+    max-width: 150pt;
     padding-left: 0pt;
     text-align: right;
     vertical-align: top;

--- a/app-ui/src/lib/traceview/TraceView.scss
+++ b/app-ui/src/lib/traceview/TraceView.scss
@@ -735,10 +735,12 @@ table.json {
 
   tr td:first-child {
     min-width: 100pt;
+    max-width: 100pt;
     padding-left: 0pt;
     text-align: right;
     vertical-align: top;
     padding-left: 20pt;
+    overflow-wrap: break-word;
   }
 
   tr td:nth-child(2) {


### PR DESCRIPTION
- hide log out when run in local
- fix updown feedback button in json.table
- for edge case with long key string, the cell width is fixed and text is breaked, showed in next line

trello task: https://trello.com/c/ozeWzTFs

screenshot:
<img width="1191" alt="Screenshot 2025-01-08 at 17 19 02" src="https://github.com/user-attachments/assets/fde97db3-b54a-4fb5-8f97-e607a25102dd" />
