### PR TITLE
Fix annotation count update on the Sidebad on click of thumbs up / down.

### DIFF
--- a/app-ui/src/AnnotationAugmentedTraceView.jsx
+++ b/app-ui/src/AnnotationAugmentedTraceView.jsx
@@ -336,6 +336,9 @@ export function AnnotationAugmentedTraceView(props) {
           setEvents={setEvents}
           allExpanded={is_all_expanded}
           topLevelAnnotations={top_level_annotations}
+          traceIndex={activeTraceIndex}
+          onUpvoteDownvoteCreate={onAnnotationCreate}
+          onUpvoteDownvoteDelete={onAnnotationDelete}
         />
       </div>
       <Tooltip
@@ -359,6 +362,9 @@ function TraceViewContent(props) {
     errors,
     decorator,
     setEvents,
+    traceIndex,
+    onUpvoteDownvoteCreate,
+    onUpvoteDownvoteDelete
   } = props;
   const EmptyComponent =
     props.empty || (() => <div className="empty">No trace selected</div>);
@@ -401,6 +407,9 @@ function TraceViewContent(props) {
       }
       allExpanded={props.allExpanded}
       traceId={activeTraceId}
+      traceIndex={traceIndex}
+      onUpvoteDownvoteCreate={onUpvoteDownvoteCreate}
+      onUpvoteDownvoteDelete={onUpvoteDownvoteDelete}
     />
   );
 }

--- a/app-ui/src/lib/traceview/line.tsx
+++ b/app-ui/src/lib/traceview/line.tsx
@@ -50,6 +50,9 @@ export function Line(props: {
   highlightContext?: HighlightContext;
   address?: string;
   highlights?: GroupedHighlight[];
+  traceIndex?: number;
+  onUpvoteDownvoteCreate?: (traceIndex: number) => void;
+  onUpvoteDownvoteDelete?: (traceIndex: number) => void;
 }) {
   const decorator = props.highlightContext?.decorator;
   const telemetry = useTelemetry();
@@ -131,7 +134,14 @@ export function Line(props: {
     let existing =
       userInfo?.id &&
       existingThumbAnnotations.find((a) => a["user"]["id"] === userInfo?.id);
+    let isToggle = existing?.["content"] === THUMBS_DOWN;
     if (existing) {
+      if (
+        props.onUpvoteDownvoteDelete &&
+        props.traceIndex !== undefined &&
+        !isToggle
+      )
+        props.onUpvoteDownvoteDelete(props.traceIndex);
       annotator
         ?.delete(existing["id"])
         .then(() => {
@@ -143,7 +153,7 @@ export function Line(props: {
       e.stopPropagation();
 
       // if same as before, untoggle it
-      if (existing["content"] === THUMBS_UP) {
+      if (!isToggle) {
         return;
       }
       // otherwise add opposite
@@ -155,6 +165,12 @@ export function Line(props: {
       ?.create({ address: props.address, content: THUMBS_UP })
       .then(() => {
         annotator?.refresh();
+        if (
+          props.onUpvoteDownvoteCreate &&
+          props.traceIndex !== undefined &&
+          !isToggle
+        )
+          props.onUpvoteDownvoteCreate(props.traceIndex);
       })
       .catch((error) => {
         console.error("error saving thumbs up", error);
@@ -177,7 +193,14 @@ export function Line(props: {
     let existing =
       userInfo?.id &&
       existingThumbAnnotations.find((a) => a["user"]["id"] === userInfo?.id);
+    let isToggle = existing?.["content"] === THUMBS_UP;
     if (existing) {
+      if (
+        props.onUpvoteDownvoteDelete &&
+        props.traceIndex !== undefined &&
+        !isToggle
+      )
+        props.onUpvoteDownvoteDelete(props.traceIndex);
       annotator
         ?.delete(existing["id"])
         .then(() => {
@@ -189,7 +212,7 @@ export function Line(props: {
       e.stopPropagation();
 
       // if same as before, untoggle it
-      if (existing["content"] === THUMBS_DOWN) {
+      if (!isToggle) {
         return;
       }
       // otherwise add opposite
@@ -201,6 +224,12 @@ export function Line(props: {
       ?.create({ address: props.address, content: THUMBS_DOWN })
       .then(() => {
         annotator?.refresh();
+        if (
+          props.onUpvoteDownvoteCreate &&
+          props.traceIndex !== undefined &&
+          !isToggle
+        )
+          props.onUpvoteDownvoteCreate(props.traceIndex);
       })
       .catch((error) => {
         console.error("error saving thumbs down", error);

--- a/app-ui/src/lib/traceview/plugins/code-highlighter.tsx
+++ b/app-ui/src/lib/traceview/plugins/code-highlighter.tsx
@@ -16,6 +16,9 @@ interface CodeHighlightedViewProps {
   highlights: any;
   highlightContext: any;
   address: string;
+  traceIndex?: number;
+  onUpvoteDownvoteCreate?: (traceIndex: number) => void;
+  onUpvoteDownvoteDelete?: (traceIndex: number) => void;
 }
 
 // a token as produced by the shiki highlighter
@@ -343,6 +346,9 @@ class CodeHighlightedView extends React.Component<
           highlights={line_highlights}
           highlightContext={this.props.highlightContext}
           address={this.props.address + ":L" + elements.length}
+          traceIndex={this.props.traceIndex}
+          onUpvoteDownvoteCreate={this.props.onUpvoteDownvoteCreate}
+          onUpvoteDownvoteDelete={this.props.onUpvoteDownvoteDelete}
         >
           {line}
           {"\n"}

--- a/app-ui/src/lib/traceview/plugins/image-viewer.tsx
+++ b/app-ui/src/lib/traceview/plugins/image-viewer.tsx
@@ -14,6 +14,9 @@ interface ImageViewerProps {
   highlights: any;
   highlightContext: any;
   address: string;
+  traceIndex?: number;
+  onUpvoteDownvoteCreate?: (traceIndex: number) => void;
+  onUpvoteDownvoteDelete?: (traceIndex: number) => void;
 }
 
 function extractImageId(content: string): {
@@ -200,6 +203,9 @@ class ImageViewer extends React.Component<
           highlights={highlights}
           highlightContext={this.props.highlightContext}
           address={this.props.address + ":L" + elements.length}
+          traceIndex={this.props.traceIndex}
+          onUpvoteDownvoteCreate={this.props.onUpvoteDownvoteCreate}
+          onUpvoteDownvoteDelete={this.props.onUpvoteDownvoteDelete}
         >
           {image}
           {"\n"}

--- a/app-ui/src/lib/traceview/traceview.tsx
+++ b/app-ui/src/lib/traceview/traceview.tsx
@@ -387,6 +387,12 @@ interface RenderedTraceProps {
   // (used to initialize expanded state of messages when they are loaded in
   // after the user has already expanded/collapsed all messages)
   allExpanded?: boolean;
+  // The index of the trace.
+  traceIndex?: number;
+  // Callback for the addition of upvote/downvote.
+  onUpvoteDownvoteCreate?: (traceIndex: number) => void;
+  // Callback for the removal of upvote/downvote.
+  onUpvoteDownvoteDelete?: (traceIndex: number) => void;
 }
 
 // state for the RenderedTrace component
@@ -620,6 +626,9 @@ export class RenderedTrace extends React.Component<
                   address={"messages[" + index + "]"}
                   events={this.state.events}
                   allExpanded={this.props.allExpanded}
+                  traceIndex={this.props.traceIndex}
+                  onUpvoteDownvoteCreate={this.props.onUpvoteDownvoteCreate}
+                  onUpvoteDownvoteDelete={this.props.onUpvoteDownvoteDelete}
                 />
               );
             }}
@@ -679,6 +688,12 @@ interface MessageViewProps {
   // (used to initialize expanded state of messages when they are loaded in
   // after the user has already expanded/collapsed all messages)
   allExpanded?: boolean;
+  // The index of the trace.
+  traceIndex?: number;
+  // Callback for the addition of upvote/downvote.
+  onUpvoteDownvoteCreate?: (traceIndex: number) => void;
+  // Callback for the removal of upvote/downvote.
+  onUpvoteDownvoteDelete?: (traceIndex: number) => void;
 }
 
 /**
@@ -874,6 +889,9 @@ class MessageView extends React.Component<
                       highlightContext={this.props.highlightContext}
                       address={this.props.address}
                       message={message}
+                      traceIndex={this.props.traceIndex}
+                      onUpvoteDownvoteCreate={this.props.onUpvoteDownvoteCreate}
+                      onUpvoteDownvoteDelete={this.props.onUpvoteDownvoteDelete}
                     />
                   </div>
                 </>
@@ -938,6 +956,9 @@ class MessageView extends React.Component<
                         highlightContext={this.props.highlightContext}
                         address={this.props.address + ".content"}
                         message={message}
+                        traceIndex={this.props.traceIndex}
+                        onUpvoteDownvoteCreate={this.props.onUpvoteDownvoteCreate}
+                        onUpvoteDownvoteDelete={this.props.onUpvoteDownvoteDelete}
                       />
                     ) : (
                       <Annotated
@@ -945,6 +966,9 @@ class MessageView extends React.Component<
                         highlightContext={this.props.highlightContext}
                         address={this.props.address + ".content"}
                         message={message}
+                        traceIndex={this.props.traceIndex}
+                        onUpvoteDownvoteCreate={this.props.onUpvoteDownvoteCreate}
+                        onUpvoteDownvoteDelete={this.props.onUpvoteDownvoteDelete}
                       >
                         {truncate_content(
                           message.content,
@@ -973,6 +997,9 @@ class MessageView extends React.Component<
                             this.props.address + ".tool_calls[" + index + "]"
                           }
                           message={message}
+                          traceIndex={this.props.traceIndex}
+                          onUpvoteDownvoteCreate={this.props.onUpvoteDownvoteCreate}
+                          onUpvoteDownvoteDelete={this.props.onUpvoteDownvoteDelete}
                         />
                       );
                     })}
@@ -996,6 +1023,9 @@ function MessageJSONContent(props: {
   highlightContext?: HighlightContext;
   address: string;
   message?: any;
+  traceIndex?: number;
+  onUpvoteDownvoteCreate?: (traceIndex: number) => void;
+  onUpvoteDownvoteDelete?: (traceIndex: number) => void;
 }) {
   const content = props.content;
   const highlights = props.highlights;
@@ -1016,6 +1046,9 @@ function MessageJSONContent(props: {
                   address={props.address + "." + key}
                   highlightContext={props.highlightContext}
                   message={props.message}
+                  traceIndex={props.traceIndex}
+                  onUpvoteDownvoteCreate={props.onUpvoteDownvoteCreate}
+                  onUpvoteDownvoteDelete={props.onUpvoteDownvoteDelete}
                 >
                   {typeof content[key] === "object"
                     ? JSON.stringify(content[key], null, 2)
@@ -1041,6 +1074,9 @@ function ToolCallView(props: {
   highlightContext?: HighlightContext;
   address: string;
   message?: any;
+  traceIndex?: number;
+  onUpvoteDownvoteCreate?: (traceIndex: number) => void;
+  onUpvoteDownvoteDelete?: (traceIndex: number) => void;
 }) {
   const tool_call = props.tool_call;
   const highlights = props.highlights;
@@ -1068,6 +1104,9 @@ function ToolCallView(props: {
           highlightContext={props.highlightContext}
           address={props.address + ".function.name"}
           message={props.message}
+          traceIndex={props.traceIndex}
+          onUpvoteDownvoteCreate={props.onUpvoteDownvoteCreate}
+          onUpvoteDownvoteDelete={props.onUpvoteDownvoteDelete}
         >
           {f.name || (
             <span className="error">Could Not Parse Function Name</span>
@@ -1083,6 +1122,9 @@ function ToolCallView(props: {
             highlightContext={props.highlightContext}
             address={props.address + ".function.arguments"}
             message={props.message}
+            traceIndex={props.traceIndex}
+            onUpvoteDownvoteCreate={props.onUpvoteDownvoteCreate}
+            onUpvoteDownvoteDelete={props.onUpvoteDownvoteDelete}
           ></HighlightedJSONTable>
         </pre>
       </div>
@@ -1103,6 +1145,9 @@ function HighlightedJSONTable(props: {
   highlightContext?: HighlightContext;
   address: string;
   message?: any;
+  traceIndex?: number;
+  onUpvoteDownvoteCreate?: (traceIndex: number) => void;
+  onUpvoteDownvoteDelete?: (traceIndex: number) => void;
 }) {
   const tool_call = props.tool_call;
   const highlights = props.highlights;
@@ -1134,6 +1179,9 @@ function HighlightedJSONTable(props: {
           address={props.address}
           message={props.message}
           highlightContext={props.highlightContext}
+          traceIndex={props.traceIndex}
+          onUpvoteDownvoteCreate={props.onUpvoteDownvoteCreate}
+          onUpvoteDownvoteDelete={props.onUpvoteDownvoteDelete}
         >
           {truncate_content(args, config("truncation_limit"))}
         </AnnotatedStringifiedJSON>
@@ -1160,6 +1208,9 @@ function HighlightedJSONTable(props: {
                   address={props.address + "." + key}
                   highlightContext={props.highlightContext}
                   message={props.message}
+                  traceIndex={props.traceIndex}
+                  onUpvoteDownvoteCreate={props.onUpvoteDownvoteCreate}
+                  onUpvoteDownvoteDelete={props.onUpvoteDownvoteDelete}
                 >
                   {typeof args[key] === "object"
                     ? JSON.stringify(args[key], null, 2)
@@ -1202,6 +1253,9 @@ function Annotated(props: {
   highlightContext?: HighlightContext;
   address?: string;
   message?: any;
+  traceIndex?: number;
+  onUpvoteDownvoteCreate?: (traceIndex: number) => void;
+  onUpvoteDownvoteDelete?: (traceIndex: number) => void;
 }) {
   const parentElement = useRef(null as any);
 
@@ -1313,6 +1367,9 @@ function Annotated(props: {
           highlights={line_highlights}
           highlightContext={props.highlightContext}
           address={props.address + ":L" + elements.length}
+          traceIndex={props.traceIndex}
+          onUpvoteDownvoteCreate={props.onUpvoteDownvoteCreate}
+          onUpvoteDownvoteDelete={props.onUpvoteDownvoteDelete}
         >
           {line}
         </Line>,
@@ -1349,6 +1406,9 @@ function AnnotatedStringifiedJSON(props: {
   highlightContext?: HighlightContext;
   address: string;
   message?: any;
+  traceIndex?: number;
+  onUpvoteDownvoteCreate?: (traceIndex: number) => void;
+  onUpvoteDownvoteDelete?: (traceIndex: number) => void;
 }) {
   const parentElement = useRef(null as any);
 
@@ -1454,6 +1514,9 @@ function AnnotatedStringifiedJSON(props: {
           highlights={highlights}
           highlightContext={props.highlightContext}
           address={props.address + ":L" + elements.length}
+          traceIndex={props.traceIndex}
+          onUpvoteDownvoteCreate={props.onUpvoteDownvoteCreate}
+          onUpvoteDownvoteDelete={props.onUpvoteDownvoteDelete}
         >
           {line}
         </Line>,


### PR DESCRIPTION
Before this change, the count was only updated after reloading the page.

Task: https://trello.com/c/0urOIUed/212-thumbs-and-thumbs-down-dont-change-the-annotation-count-on-the-sidebar-dynamically-this-requires-a-re-load