### PR TITLE
Update the get and update dataset metadata APIs.

### DIFF
--- a/tests/test-ui-api/test_dataset.py
+++ b/tests/test-ui-api/test_dataset.py
@@ -142,7 +142,7 @@ async def test_get_metadata_created_by_different_user(context, url, data_abc):
         )
         assert get_metadata_response.status == 403
 
-        # If no owner_user_id is provided, the request should fail with 404.
+        # If no owner_user_id is provided, the request should fail with 404 since the lookup is done by the caller user_id.
         get_metadata_response = await context.request.get(
             f"{url}/api/v1/dataset/metadata/{dataset['name']}",
             headers={"referer": "noauth=user1"},
@@ -153,6 +153,7 @@ async def test_get_metadata_created_by_different_user(context, url, data_abc):
         await update_dataset(context, url, dataset["id"], is_dataset_public=True)
 
         # A different user tries to get the metadata for the dataset when it is public.
+        # The lookup is done by the owner_user_id for which a dataset with the same name exists and the dataset is public.
         get_metadata_response = await context.request.get(
             f"{url}/api/v1/dataset/metadata/{dataset['name']}?owner_user_id=3752ff38-da1a-4fa5-84a2-9e44a4b167ce",
             headers={"referer": "noauth=user1"},
@@ -165,7 +166,8 @@ async def test_get_metadata_created_by_different_user(context, url, data_abc):
         assert metadata == expected_metadata
         assert "policies" not in metadata
 
-        # If no owner_user_id is provided, the request should fail with 404.
+        # If no owner_user_id is provided and the caller is not the owner, the request should fail with 404.
+        # The lookup is done by the caller user_id for which a dataset with the same name does not exist.
         get_metadata_response = await context.request.get(
             f"{url}/api/v1/dataset/metadata/{dataset['name']}",
             headers={"referer": "noauth=user1"},

--- a/tests/test-ui-api/test_dataset.py
+++ b/tests/test-ui-api/test_dataset.py
@@ -116,8 +116,15 @@ async def test_get_own_metadata(context, url, data_abc):
 
 async def test_get_metadata_for_non_existent_dataset_fails(context, url):
     """Tests that getting metadata of a non-existent dataset fails."""
+    # Get metadata for a non-existent dataset for the caller user_id.
     get_metadata_response = await context.request.get(
         f"{url}/api/v1/dataset/metadata/some_dataset"
+    )
+    assert get_metadata_response.status == 404
+    
+    # Get metadata for a non-existent dataset for a different user_id.
+    get_metadata_response = await context.request.get(
+        f"{url}/api/v1/dataset/metadata/some_dataset?owner_user_id=3752ff38-da1a-4fa5-84a2-9e44a4b167ce"
     )
     assert get_metadata_response.status == 404
 


### PR DESCRIPTION
A `dataset_name` can be the same across users but the combination of a `dataset_name` and a `user` is unique. Both the id (UUID) and the username (string) of a user are unique.

### For the `UpdateDatasetMetadata` API:
- Updates to the dataset metadata are permitted **only by the owner** of the dataset.  
- If a caller who **does not own** the dataset attempts to update it, the API returns a **404 Not Found** during the dataset lookup.

---

### For the `GetDatasetMetadata` API:
- A new query parameter called **`owner_username`** has been introduced.  
- **If  `owner_username` is not passed**: 
   - The caller `user_id` is used for the dataset lookup. If a dataset of that name is found, its metadata is returned **regardless of whether it is public or private** else we return a **404 Not Found**.

- **If `owner_username` is passed and it matches the caller's user:**  
   - The API performs a **standard lookup** using `owner_username`.
   - If a dataset with the given name is found, it is returned **regardless of whether it is public or private** else it returns a **404 Not Found**.

- **If `owner_username` is passed and it differs from the caller's user:**  
   - The API performs a **standard lookup** using `owner_username`. If a dataset is not found, it returns a **404 Not Found**.
   - The API returns the dataset metadata **only if the dataset is public**.  
   - If the dataset is private, the API responds with a **403 Forbidden** error.  

Trello task: https://trello.com/c/j4nQixgY/140-issue-with-metadata-api