### PR TITLE
Use pool_size while calling sqlalchemy.create_engine. 

### DIFF
--- a/app-api/database/database_manager.py
+++ b/app-api/database/database_manager.py
@@ -1,0 +1,40 @@
+"""Database manager singleton class."""
+
+import os
+import threading
+
+from sqlalchemy import create_engine
+
+
+class DatabaseManager:
+    """Singleton class for the SQLAlchemy engine."""
+
+    _engine = None
+    _lock = threading.Lock()
+
+    def __new__(cls):
+        """Prevent direct instantiation of the class."""
+        raise RuntimeError("Use DatabaseManager.get_engine() instead")
+
+    @staticmethod
+    def get_engine():
+        """Initialize and return the single SQLAlchemy engine instance."""
+        if DatabaseManager._engine is None:
+            with DatabaseManager._lock:
+                if DatabaseManager._engine is None:
+                    DatabaseManager._engine = create_engine(
+                        DatabaseManager.get_db_url(),
+                        pool_size=os.environ.get("DB_POOL_SIZE", 10),
+                        max_overflow=os.environ.get("DB_MAX_OVERFLOW", 5),
+                        pool_recycle=1800,
+                        pool_pre_ping=True,
+                    )
+        return DatabaseManager._engine
+
+    @staticmethod
+    def get_db_url():
+        """Return the database URL."""
+        return (
+            f"postgresql://{os.getenv('POSTGRES_USER')}:{os.getenv('POSTGRES_PASSWORD')}"
+            f"@{os.getenv('POSTGRES_HOST')}:5432/{os.getenv('POSTGRES_DB')}"
+        )

--- a/app-api/database/env.py
+++ b/app-api/database/env.py
@@ -3,13 +3,14 @@ from logging.config import fileConfig
 from alembic import context
 from models.datasets_and_traces import *
 from sqlalchemy import engine_from_config, pool
+from database.database_manager import DatabaseManager
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
 
 # programmatically set the target url
-config.set_main_option("sqlalchemy.url", get_db_url())
+config.set_main_option("sqlalchemy.url", DatabaseManager.get_db_url())
 
 
 # Interpret the config file for Python logging.

--- a/app-api/models/datasets_and_traces.py
+++ b/app-api/models/datasets_and_traces.py
@@ -13,13 +13,12 @@ from sqlalchemy import (
     Integer,
     String,
     UniqueConstraint,
-    create_engine,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import DeclarativeBase, mapped_column
 from sqlalchemy.sql import func
-
+from database.database_manager import DatabaseManager
 
 class Base(DeclarativeBase):
     pass
@@ -185,19 +184,8 @@ class DatasetPolicy(BaseModel):
         """Represents the object as a dictionary."""
         return self.model_dump()
 
-
-def get_db_url():
-    return "postgresql://{}:{}@{}:5432/{}".format(
-        os.environ["POSTGRES_USER"],
-        os.environ["POSTGRES_PASSWORD"],
-        os.environ["POSTGRES_HOST"],
-        os.environ["POSTGRES_DB"],
-    )
-
-
 def db():
     """
     Returns a SQLAlchemy engine object that is connected to the database.
     """
-    client = create_engine(get_db_url())
-    return client
+    return DatabaseManager.get_engine()

--- a/tests/test-ui/test_basic.py
+++ b/tests/test-ui/test_basic.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import time
 
 # add tests folder (parent) to sys.path
 import sys
@@ -191,10 +192,10 @@ async def test_create_empty_dataset_and_then_upload_file(
         await file_chooser.set_files(fn)
         await screenshot(page)
         await page.get_by_label("Upload").click()
-
+    
     # verify that the traces are shown
-    await trace_shown_in_sidebar(page, "Run 1")
-    await trace_shown_in_sidebar(page, "Run 2")
+    await page.wait_for_selector("text=Run 1")
+    await page.wait_for_selector("text=Run 2")
     await screenshot(page)
 
     # delete dataset


### PR DESCRIPTION
Also cache the resultant engine client so that it is not re-created for each query.