### PR TITLE
Mixed content rendering for JSON arrays in messages

### DIFF
--- a/app-api/models/queries.py
+++ b/app-api/models/queries.py
@@ -297,11 +297,18 @@ async def images_to_base64(trace):
     if "uploader" in trace.extra_metadata:
         trace.extra_metadata.pop("uploader")
 
-    image_tasks = [
-        (convert_local_image_link_to_base64(message.get('content')), i)
-        for i, message in enumerate(trace.content)
-        if (msg := message.get('content')) and msg.startswith('local_img_link')
-    ]
+    image_tasks = []
+
+    for i, message in enumerate(trace.content):
+        if (
+            isinstance(message, dict) and
+            'content' in message and 
+            isinstance(message.get('content'), str) 
+            and message.get('content').startswith('local_img_link')
+        ):
+            image_tasks.append(
+                (convert_local_image_link_to_base64(message.get('content')), i)
+            )
 
     images = await asyncio.gather(*[task[0] for task in image_tasks])
 

--- a/app-ui/src/lib/traceview/TraceView.scss
+++ b/app-ui/src/lib/traceview/TraceView.scss
@@ -524,11 +524,16 @@ body {
     line-height: 1.4em;
   }
 
+  .annotated-parent:last-child {
+    padding-bottom: 0pt;
+  }
+
   .annotated-parent {
     font-size: 12pt;
     position: relative;
     padding: 0pt;
     margin: -5pt;
+    padding-bottom: 5pt;
 
     &:not(:hover) button.plugin-toggle {
       opacity: 0;

--- a/app-ui/src/lib/traceview/plugins/code-highlighter.tsx
+++ b/app-ui/src/lib/traceview/plugins/code-highlighter.tsx
@@ -553,3 +553,5 @@ class LanguageClassifier {
 }
 
 const LANGUAGE_CLASSIFIER = new LanguageClassifier();
+
+export default CodeHighlightedView;

--- a/app-ui/src/lib/traceview/plugins/image-viewer.tsx
+++ b/app-ui/src/lib/traceview/plugins/image-viewer.tsx
@@ -385,7 +385,7 @@ class ImageViewer extends React.Component<
     }
 
     // iterate over the following messages
-    for (let i = index + 1; i < this.props.messages.length; i++) {
+    for (let i = index + 1; i < this.props.messages?.length; i++) {
       for (let tc of (this.props.messages[i].tool_calls || [])) {
         for (let value of Object.values(tc.function?.arguments || {})) {
           let coordinates = extractCoordinates(value);
@@ -451,3 +451,6 @@ register_plugin({
     return false;
   },
 });
+
+
+export default ImageViewer;


### PR DESCRIPTION
When a JSON array is present in a message, we can now render each element in the array independently. This allows us to do mixed content rendering, like having an image and a piece of text in the same message in a trace.

We assume that elements in the array have a `type` field, and if not, we render them as regular JSON data.