### PR TITLE
fix: type hinting for user authentication

### DIFF
--- a/app-api/models/datasets_and_traces.py
+++ b/app-api/models/datasets_and_traces.py
@@ -17,7 +17,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import DeclarativeBase, mapped_column
+from sqlalchemy.orm import DeclarativeBase, mapped_column, Mapped
 from sqlalchemy.sql import func
 from database.database_manager import DatabaseManager
 
@@ -34,13 +34,13 @@ class Dataset(Base):
     )
 
     # key is uuid that auto creates
-    id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     # user owning the dataset
-    user_id = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    user_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     # name of the dataset
-    name = mapped_column(String, nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False)
     # is the dataset visible to other users
-    is_public = mapped_column(Boolean, default=False, nullable=False)
+    is_public: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     time_created = mapped_column(
         DateTime(timezone=True), nullable=False, default=func.now()
     )
@@ -52,13 +52,13 @@ class SavedQueries(Base):
     __objectname__ = "SavedQueries"
     __tablename__ = "queries"
 
-    id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    name = mapped_column(String, nullable=False)
-    user_id = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-    dataset_id = mapped_column(
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    user_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    dataset_id: Mapped[UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("datasets.id"), nullable=False
     )
-    query = mapped_column(String, nullable=True)
+    query: Mapped[str] = mapped_column(String, nullable=True)
 
 
 class Trace(Base):
@@ -69,20 +69,20 @@ class Trace(Base):
     )
 
     # key is uuid that auto creates
-    id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     # int index of trace in dataset
-    index = mapped_column(Integer, nullable=False)
+    index: Mapped[int] = mapped_column(Integer, nullable=False)
     # foreign dataset id that this trace belongs to
-    dataset_id = mapped_column(
+    dataset_id: Mapped[UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("datasets.id"), nullable=True
     )
     # user that uploaded the trace
-    user_id = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    user_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     # display name of the trace
-    name = mapped_column(String, nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False)
 
     # hierarchy path of the trace
-    hierarchy_path = mapped_column(ARRAY(String), nullable=False)
+    hierarchy_path: Mapped[str] = mapped_column(ARRAY(String), nullable=False)
 
     content = mapped_column(JSON, nullable=False)
     extra_metadata = mapped_column(JSON, nullable=False)
@@ -105,9 +105,9 @@ class User(Base):
     # this is NOT used for auth (see routes/auth.py), but just to map user_id -> display, image_path
 
     # key is uuid that must be supplied
-    id = mapped_column(UUID(as_uuid=True), primary_key=True)
-    username = mapped_column(String, nullable=False, unique=True)
-    image_url_hash = mapped_column(String, nullable=False)
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    username: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    image_url_hash: Mapped[str] = mapped_column(String, nullable=False)
 
 
 class Annotation(Base):
@@ -118,17 +118,17 @@ class Annotation(Base):
     )
 
     # key is uuid that auto creates
-    id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     # foreign trace id that this annotation belongs to
-    trace_id = mapped_column(
+    trace_id: Mapped[UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("traces.id"), nullable=False
     )
     # foreign user id that this annotation belongs to
-    user_id = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    user_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     # JSON object of the annotation
-    content = mapped_column(String, nullable=False)
+    content: Mapped[str] = mapped_column(String, nullable=False)
     # address within the trace that this annotation belongs to (e.g. message, offset, etc.)
-    address = mapped_column(String, nullable=False)
+    address: Mapped[str] = mapped_column(String, nullable=False)
     # timestamp of the creation of the comment
     time_created = mapped_column(
         DateTime(timezone=True), nullable=False, default=func.now()
@@ -151,9 +151,9 @@ class SharedLinks(Base):
     __tablename__ = "shared_links"
 
     # key is uuid that auto creates
-    id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     # foreign user id that this shared link belongs to
-    trace_id = mapped_column(
+    trace_id: Mapped[UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("traces.id"), nullable=False
     )
     # timestamp of the sharing of the trace
@@ -170,19 +170,19 @@ class APIKey(Base):
     )
 
     # key id
-    id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     # Hashed key (sha256 + last 4 characters of original key)
     #  - Show [-4:] of this to the user to enable them to distinguish between keys.
     #  - Showing the rest would be a security risk, as they could then try to brute force the key.
-    hashed_key = mapped_column(String, primary_key=True)
+    hashed_key: Mapped[str] = mapped_column(String, primary_key=True)
     # foreign user id that this api key belongs to
-    user_id = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    user_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     # timestamp of the creation of the api key
     time_created = mapped_column(
         DateTime(timezone=True), nullable=False, default=func.now()
     )
     # expired (true if the key has been revoked)
-    expired = mapped_column(Boolean, nullable=False, default=False)
+    expired: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     @staticmethod
     def hash_key(key):

--- a/app-api/models/importers.py
+++ b/app-api/models/importers.py
@@ -11,7 +11,6 @@ from typing import Dict
 
 from fastapi import HTTPException
 from models.datasets_and_traces import Annotation, Dataset, Trace
-from models.queries import *
 from sqlalchemy.orm import Session
 from util.util import parse_and_update_messages
 

--- a/app-api/models/queries.py
+++ b/app-api/models/queries.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import re
-import uuid
+from uuid import UUID, uuid4
 
 import aiofiles
 import asyncio
@@ -20,6 +20,7 @@ from models.importers import import_jsonl
 from sqlalchemy import and_
 from sqlalchemy.dialects.sqlite import insert as sqlite_upsert
 from sqlalchemy.sql import func
+from sqlalchemy.orm import Session
 from sqlalchemy.sql.expression import cast
 from util.config import config
 from util.util import get_gravatar_hash, truncate_trace_content
@@ -28,12 +29,13 @@ import base64
 
 
 def load_trace(
-    session, by, user_id, allow_shared=False, allow_public=False, return_user=False
+    session: Session, by: UUID | str, user_id: UUID, allow_shared:bool=False, allow_public:bool=False, return_user:bool=False
 ):
-    try:
-        by = uuid.UUID(str(by))
-    except ValueError:
-        raise HTTPException(status_code=404, detail="Trace not a valid UUID")
+    if not isinstance(by, UUID):
+        try:
+            by = UUID(str(by))
+        except ValueError:
+            raise HTTPException(status_code=404, detail="Trace not a valid UUID")
     query_filter = get_query_filter(by, Trace, User)
     if return_user:
         # join on user_id to get real user name
@@ -46,16 +48,15 @@ def load_trace(
         if result is None:
             raise HTTPException(status_code=404, detail="Trace not found")
         else:
-            trace, user = result
+            trace, user = result.tuple()
     else:
         trace = session.query(Trace).filter(query_filter).first()
     if trace is None:
         raise HTTPException(status_code=404, detail="Trace not found")
 
     dataset = session.query(Dataset).filter(Dataset.id == trace.dataset_id).first()
-
     if not (
-        str(trace.user_id) == str(user_id)  # correct user
+        trace.user_id == user_id  # correct user
         or (allow_shared and has_link_sharing(session, trace.id))  # in sharing mode
         or (
             dataset is not None and allow_public and dataset.is_public
@@ -73,7 +74,7 @@ def load_trace(
 
 
 # TODO: Fix typo in the function name
-def load_annotations(session, by):
+def load_annotations(session: Session, by):
     query_filter = get_query_filter(by, Annotation, User, default_key="trace_id")
     return (
         session.query(Annotation, User)
@@ -99,9 +100,8 @@ def get_query_filter(by, main_object, *other_objects, default_key="id"):
     return and_(*query_filter)
 
 
-def load_dataset(session, by, user_id, allow_public=False, return_user=False):
+def load_dataset(session: Session, by, user_id: UUID, allow_public=False, return_user=False):
     query_filter = get_query_filter(by, Dataset, User)
-
     # join on user_id to get real user name
     result = (
         session.query(Dataset, User)
@@ -175,7 +175,7 @@ def get_savedqueries(session, dataset: Dataset, user_id, num_traces: int):
     return queries
 
 
-def has_link_sharing(session, trace_id):
+def has_link_sharing(session: Session, trace_id: UUID):
     try:
         trace = (
             session.query(SharedLinks).filter(SharedLinks.trace_id == trace_id).first()
@@ -217,7 +217,7 @@ def save_user(session, userinfo):
 
         # Create the dataset
         dataset = Dataset(
-            id=uuid.uuid4(),
+            id=uuid4(),
             user_id=user["id"],
             name="Welcome-to-Explorer",
             extra_metadata=metadata,

--- a/app-api/models/queries.py
+++ b/app-api/models/queries.py
@@ -100,7 +100,7 @@ def get_query_filter(by, main_object, *other_objects, default_key="id"):
     return and_(*query_filter)
 
 
-def load_dataset(session: Session, by, user_id: UUID, allow_public=False, return_user=False):
+def load_dataset(session: Session, by: dict, user_id: UUID, allow_public=False, return_user=False):
     query_filter = get_query_filter(by, Dataset, User)
     # join on user_id to get real user name
     result = (
@@ -111,10 +111,8 @@ def load_dataset(session: Session, by, user_id: UUID, allow_public=False, return
     )
     if result is None:
         raise HTTPException(status_code=404, detail="Dataset not found")
-    dataset, user = result
+    dataset, user = result.tuple()
 
-    if dataset is None:
-        raise HTTPException(status_code=404, detail="Dataset not found")
     if not (allow_public and dataset.is_public or str(dataset.user_id) == str(user_id)):
         raise HTTPException(status_code=401, detail="Unauthorized get")
     # If the dataset is public but the requestor is not the owner, remove the policies from the dataset response.
@@ -426,12 +424,12 @@ def query_traces(session, dataset, query, count=False):
                         try:
                             rhs = float(rhs)
                             rhs_type = "float"
-                        except:
+                        except Exception:
                             pass
                         try:
                             rhs = int(rhs)
                             rhs_type = "int"
-                        except:
+                        except Exception:
                             pass
 
                     if rhs_type == "str":

--- a/app-api/models/queries.py
+++ b/app-api/models/queries.py
@@ -348,7 +348,7 @@ def annotation_to_exported_json(annotation, user=None, **kwargs):
     return out
 
 
-def user_to_json(user):
+def user_to_json(user: User):
     return {
         "id": user.id,
         "username": user.username,

--- a/app-api/routes/apikeys.py
+++ b/app-api/routes/apikeys.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from fastapi import Depends, FastAPI, HTTPException, Request
 from models.datasets_and_traces import APIKey, db
 from models.queries import *
-from routes.auth import AuthenticatedUserIdentity, UserIdentity
+from routes.auth import AuthenticatedUserIdentity, UserIdentity, DEVELOPER_USER, DEVELOPER_USER2
 from sqlalchemy.orm import Session
 
 # dataset routes
@@ -103,12 +103,12 @@ async def APIIdentity(request: Request) -> UUID:
         if os.getenv("DEV_MODE") == "true" and "noauth" not in request.headers.get(
             "referer", []
         ):
-            return UUID("3752ff38-da1a-4fa5-84a2-9e44a4b167ce")
+            return UUID(DEVELOPER_USER["sub"])
         if (
             "noauth=user1" in request.headers.get("referer", [])
             and os.getenv("DEV_MODE") == "true"
         ):
-            return UUID("3752ff38-da1a-4fa5-84a2-9e44a4b167ca")
+            return UUID(DEVELOPER_USER2["sub"])
 
         apikey = request.headers.get("Authorization")
         bearer_token = re.match(r"Bearer (.+)", apikey)

--- a/app-api/routes/apikeys.py
+++ b/app-api/routes/apikeys.py
@@ -6,7 +6,6 @@ from uuid import UUID
 
 from fastapi import Depends, FastAPI, HTTPException, Request
 from models.datasets_and_traces import APIKey, db
-from models.queries import *
 from routes.auth import AuthenticatedUserIdentity, UserIdentity, DEVELOPER_USER, DEVELOPER_USER2
 from sqlalchemy.orm import Session
 

--- a/app-api/routes/apikeys.py
+++ b/app-api/routes/apikeys.py
@@ -103,7 +103,7 @@ async def APIIdentity(request: Request) -> UUID:
         if os.getenv("DEV_MODE") == "true" and "noauth" not in request.headers.get(
             "referer", []
         ):
-            return UUID("3752ff38-da1a-4fa5-84a2-9e44a4b167ca")
+            return UUID("3752ff38-da1a-4fa5-84a2-9e44a4b167ce")
         if (
             "noauth=user1" in request.headers.get("referer", [])
             and os.getenv("DEV_MODE") == "true"

--- a/app-api/routes/auth.py
+++ b/app-api/routes/auth.py
@@ -22,6 +22,18 @@ keycloak_openid = KeycloakOpenID(
     client_secret_key=os.getenv("KEYCLOAK_CLIENT_ID_SECRET"),
 )
 
+DEVELOPER_USER = {
+    "sub": "3752ff38-da1a-4fa5-84a2-9e44a4b167ce",
+    "email": "dev@mail.com",
+    "username": "developer",
+    "name": "Developer"
+}
+DEVELOPER_USER2 = {
+    "sub": "3752ff38-da1a-4fa5-84a2-9e44a4b167ca",
+    "email": "dev2@mail.com",
+    "username": "developer2",
+    "name": "Developer2"
+}
 
 def install_authorization_endpoints(app):
     """
@@ -97,30 +109,20 @@ async def UserIdentity(request: Request) -> UUID | None:
     if os.getenv("DEV_MODE") == "true" and "noauth" not in request.headers.get(
         "referer", []
     ):
+        request.state.userinfo = DEVELOPER_USER
         # set jwt cookie for dev mode
         request.state.refreshed_token = {
             "access_token": "dev-access",
-            "refresh_token": "dev-refresh",
+            "refresh_token": "dev-refresh"
         }
 
-        request.state.userinfo = {
-            "sub": "3752ff38-da1a-4fa5-84a2-9e44a4b167ce",
-            "email": "dev@mail.com",
-            "username": "developer",
-            "name": "Developer",
-        }
         return UUID(request.state.userinfo["sub"])
 
     if (
         "noauth=user1" in request.headers.get("referer", [])
         and os.getenv("DEV_MODE") == "true"
     ):
-        request.state.userinfo = {
-            "sub": "3752ff38-da1a-4fa5-84a2-9e44a4b167ca",
-            "email": "dev2@mail.com",
-            "username": "developer2",
-            "name": "Developer2",
-        }
+        request.state.userinfo = DEVELOPER_USER2
         # set jwt cookie for dev mode
         request.state.refreshed_token = {
             "access_token": "dev-access",

--- a/app-api/routes/auth.py
+++ b/app-api/routes/auth.py
@@ -59,7 +59,7 @@ def install_authorization_endpoints(app):
                 scope="openid profile email",
             )
 
-            userinfo = await keycloak_openid.a_userinfo(access_token["access_token"])
+            _ = await keycloak_openid.a_userinfo(access_token["access_token"])
             response.set_cookie(
                 key="jwt", value=json.dumps(access_token), httponly=True
             )

--- a/app-api/routes/auth.py
+++ b/app-api/routes/auth.py
@@ -1,6 +1,7 @@
 import json
 import os
 from typing import Annotated
+from uuid import UUID
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -90,7 +91,8 @@ async def write_back_refreshed_token(request: Request, call_next):
     return response
 
 
-async def UserIdentity(request: Request):
+async def UserIdentity(request: Request) -> UUID | None:
+    # None stands for anonymous user
     # check for DEV_MODE
     if os.getenv("DEV_MODE") == "true" and "noauth" not in request.headers.get(
         "referer", []
@@ -101,28 +103,31 @@ async def UserIdentity(request: Request):
             "refresh_token": "dev-refresh",
         }
 
-        return {
+        request.state.userinfo = {
             "sub": "3752ff38-da1a-4fa5-84a2-9e44a4b167ce",
             "email": "dev@mail.com",
             "username": "developer",
             "name": "Developer",
         }
+        return UUID(request.state.userinfo["sub"])
+
     if (
         "noauth=user1" in request.headers.get("referer", [])
         and os.getenv("DEV_MODE") == "true"
     ):
-        # set jwt cookie for dev mode
-        request.state.refreshed_token = {
-            "access_token": "dev-access",
-            "refresh_token": "dev-refresh",
-        }
-
-        return {
+        request.state.userinfo = {
             "sub": "3752ff38-da1a-4fa5-84a2-9e44a4b167ca",
             "email": "dev2@mail.com",
             "username": "developer2",
             "name": "Developer2",
         }
+        # set jwt cookie for dev mode
+        request.state.refreshed_token = {
+            "access_token": "dev-access",
+            "refresh_token": "dev-refresh"
+        }
+
+        return UUID(request.state.userinfo["sub"])
 
     try:
         token = json.loads(request.cookies.get("jwt"))
@@ -136,17 +141,11 @@ async def UserIdentity(request: Request):
             request.state.refreshed_token = token
 
             userinfo = await keycloak_openid.a_userinfo(token["access_token"])
-
         request.state.userinfo = userinfo
 
         assert userinfo["sub"] is not None, "a logged-in user must have a sub"
 
-        return {
-            "sub": userinfo["sub"],
-            "email": userinfo["email"],
-            "username": userinfo["preferred_username"],
-            "name": userinfo["name"],
-        }
+        return UUID(userinfo["sub"])
     except Exception:
         # otherwise, this is an anonymous user
 
@@ -158,12 +157,12 @@ async def UserIdentity(request: Request):
             raise HTTPException(
                 status_code=401, detail="Private instance, login required"
             )
+        request.state.userinfo = None
+        # on public instances, we allow anonymous access to some endpoints. In this case, return None.
+        return None
 
-        # on public instances, we allow anonymous access to some endpoints
-        return {"sub": None, "email": "", "username": "", "name": ""}
 
-
-async def AuthenticatedUserIdentity(identity: Annotated[dict, Depends(UserIdentity)]):
-    if identity["sub"] is None:
+async def AuthenticatedUserIdentity(identity: Annotated[UUID | None, Depends(UserIdentity)]) -> UUID:
+    if identity is None:
         raise HTTPException(status_code=401, detail="Unauthorized request")
     return identity

--- a/app-api/routes/dataset.py
+++ b/app-api/routes/dataset.py
@@ -812,10 +812,10 @@ def get_traces_by_name_full(
 ########################################
 
 
-def get_all_traces(by: dict, user: Annotated[dict, Depends(UserIdentity)]):
+def get_all_traces(by: dict, user_id: Annotated[UUID, Depends(UserIdentity)]):
     with Session(db()) as session:
         dataset, user = load_dataset(
-            session, by, user["sub"], allow_public=True, return_user=True
+            session, by, user_id, allow_public=True, return_user=True
         )
 
         out = dataset_to_json(dataset)

--- a/app-api/routes/dataset.py
+++ b/app-api/routes/dataset.py
@@ -98,10 +98,9 @@ def str_to_bool(key: str, value: str) -> bool:
 
 @dataset.post("/create")
 async def create(
-    request: Request, userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)]
+    request: Request, user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)]
 ):
     """Create a dataset."""
-    user_id = userinfo["sub"]
     if user_id is None:
         raise HTTPException(
             status_code=401, detail="Must be authenticated to create a dataset"
@@ -145,7 +144,7 @@ async def create(
 @dataset.post("/upload")
 async def upload_file(
     request: Request,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
     file: UploadFile = File(...),
 ):
     """Create a dataset via file upload."""
@@ -155,7 +154,6 @@ async def upload_file(
     # is_public is a string because of Multipart request, convert to boolean
     is_public = str_to_bool("is_public", form.get("is_public", "false"))
 
-    user_id = userinfo["sub"]
     if user_id is None:
         raise HTTPException(
             status_code=401, detail="Must be authenticated to upload a dataset"
@@ -253,7 +251,7 @@ def list_datasets(
 
 @dataset.get("/list/byuser/{user_name}")
 def list_datasets_by_user(
-    request: Request, user_name: str, user: Annotated[dict, Depends(UserIdentity)]
+    request: Request, user_name: str, user: Annotated[UUID | None, Depends(UserIdentity)]
 ):
     with Session(db()) as session:
         user_exists = session.query(exists().where(User.username == user_name)).scalar()
@@ -274,9 +272,8 @@ def list_datasets_by_user(
 
 
 async def delete_dataset(
-    by: dict, userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)]
+    by: dict, user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)]
 ):
-    user_id = userinfo["sub"]
 
     with Session(db()) as session:
         dataset = load_dataset(session, by, user_id)
@@ -311,9 +308,9 @@ async def delete_dataset(
 async def delete_dataset_by_id(
     request: Request,
     id: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
-    return await delete_dataset({"id": id}, userinfo)
+    return await delete_dataset({"id": id}, user_id)
 
 
 @dataset.delete("/byuser/{username}/{dataset_name}")
@@ -321,10 +318,10 @@ async def delete_dataset_by_name(
     request: Request,
     username: str,
     dataset_name: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
     return await delete_dataset(
-        {"User.username": username, "name": dataset_name}, userinfo
+        {"User.username": username, "name": dataset_name}, user_id
     )
 
 
@@ -380,10 +377,9 @@ def search_dataset_by_name(
     request: Request,
     username: str,
     dataset_name: str,
-    userinfo: Annotated[dict, Depends(UserIdentity)],
+    user_id: Annotated[UUID | None, Depends(UserIdentity)],
     query: str = None,
 ):
-    user_id = userinfo["sub"]
     with Session(db()) as session:
         by = {"User.username": username, "name": dataset_name}
         dataset, _ = load_dataset(
@@ -457,9 +453,8 @@ async def save_query(
     request: Request,
     username: str,
     dataset_name: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
-    user_id = userinfo["sub"]
     with Session(db()) as session:
         by = {"User.username": username, "name": dataset_name}
         dataset, _ = load_dataset(
@@ -480,9 +475,8 @@ async def save_query(
 async def delete_query(
     request: Request,
     query_id: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
-    user_id = userinfo["sub"]
     with Session(db()) as session:
         query = session.query(SavedQueries).filter(SavedQueries.id == query_id).first()
 
@@ -501,10 +495,8 @@ async def delete_query(
 async def update_dataset(
     request: Request,
     by: dict,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
-    # never None, 'userinfo' is authenticated
-    user_id = userinfo["sub"]
 
     with Session(db()) as session:
         dataset, user = load_dataset(session, by, user_id, return_user=True)
@@ -526,9 +518,9 @@ async def update_dataset(
 async def update_dataset_by_id(
     request: Request,
     id: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
-    return await update_dataset(request, {"id": id}, userinfo)
+    return await update_dataset(request, {"id": id}, user_id)
 
 
 @dataset.put("/byuser/{username}/{dataset_name}")
@@ -536,10 +528,10 @@ async def update_dataset_by_name(
     request: Request,
     username: str,
     dataset_name: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
     return await update_dataset(
-        request, {"User.username": username, "name": dataset_name}, userinfo
+        request, {"User.username": username, "name": dataset_name}, user_id
     )
 
 
@@ -674,11 +666,11 @@ Download the dataset in JSONL format.
 
 @dataset.get("/byid/{id}/download")
 async def download_traces_by_id(
-    request: Request, id: str, userinfo: Annotated[dict, Depends(UserIdentity)]
+    request: Request, id: str, user_id: Annotated[UUID | None, Depends(UserIdentity)]
 ):
     with Session(db()) as session:
         dataset, user = load_dataset(
-            session, {"id": id}, userinfo["sub"], allow_public=True, return_user=True
+            session, {"id": id}, user_id, allow_public=True, return_user=True
         )
         internal_dataset_info = dataset_to_json(dataset)
         dataset_info = {
@@ -686,7 +678,7 @@ async def download_traces_by_id(
         }
         # streaming response, but triggers a download
         return StreamingResponse(
-            stream_jsonl(session, id, dataset_info, userinfo["sub"]),
+            stream_jsonl(session, id, dataset_info, user_id),
             media_type="application/json",
             headers={
                 "Content-Disposition": 'attachment; filename="'
@@ -730,11 +722,11 @@ Download all annotated traces of a dataset in JSONL format.
 
 @dataset.get("/byid/{id}/download/annotated")
 def download_annotated_traces_by_id(
-    request: Request, id: str, userinfo: Annotated[dict, Depends(UserIdentity)]
+    request: Request, id: str, user_id: Annotated[UUID | None, Depends(UserIdentity)]
 ):
     with Session(db()) as session:
         dataset, user = load_dataset(
-            session, {"id": id}, userinfo["sub"], allow_public=True, return_user=True
+            session, {"id": id}, user_id, allow_public=True, return_user=True
         )
         internal_dataset_info = dataset_to_json(dataset)
         dataset_info = {
@@ -742,7 +734,7 @@ def download_annotated_traces_by_id(
         }
         # streaming response, but triggers a download
         return StreamingResponse(
-            stream_annotated_jsonl(session, id, dataset_info, userinfo["sub"]),
+            stream_annotated_jsonl(session, id, dataset_info, user_id),
             media_type="application/json",
             headers={
                 "Content-Disposition": 'attachment; filename="'
@@ -775,10 +767,9 @@ def get_trace_indices_by_name(
     request: Request,
     username: str,
     dataset_name: str,
-    userinfo: Annotated[dict, Depends(UserIdentity)],
+    user_id: Annotated[UUID | None, Depends(UserIdentity)],
 ):
     with Session(db()) as session:
-        user_id = userinfo["sub"]
         dataset, user = load_dataset(
             session,
             {"User.username": username, "name": dataset_name},
@@ -811,9 +802,9 @@ def get_traces_by_name_full(
     request: Request,
     username: str,
     dataset_name: str,
-    userinfo: Annotated[dict, Depends(UserIdentity)],
+    user_id: Annotated[UUID | None, Depends(UserIdentity)],
 ):
-    return get_all_traces({"User.username": username, "name": dataset_name}, userinfo)
+    return get_all_traces({"User.username": username, "name": dataset_name}, user_id)
 
 
 ########################################
@@ -841,10 +832,9 @@ def get_all_traces(by: dict, user: Annotated[dict, Depends(UserIdentity)]):
 async def create_policy(
     request: Request,
     dataset_id: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
     """Creates a new policy for a dataset."""
-    user_id = userinfo["sub"]
 
     with Session(db()) as session:
         dataset = load_dataset(
@@ -892,10 +882,9 @@ async def update_policy(
     request: Request,
     dataset_id: str,
     policy_id: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
     """Updates a policy for a dataset."""
-    user_id = userinfo["sub"]
 
     with Session(db()) as session:
         dataset = load_dataset(
@@ -946,10 +935,9 @@ async def update_policy(
 async def delete_policy(
     dataset_id: str,
     policy_id: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
     """Deletes a policy for a dataset."""
-    user_id = userinfo["sub"]
 
     with Session(db()) as session:
         dataset = load_dataset(
@@ -976,7 +964,7 @@ async def delete_policy(
 @dataset.get("/metadata/{dataset_name}")
 async def get_metadata(
     dataset_name: str,
-    userinfo: Annotated[dict, Depends(APIIdentity)],
+    user_id: Annotated[UUID, Depends(APIIdentity)],
     owner_username: str = None,  # The username of the owner of the dataset (u/<username>).
 ):
     """
@@ -989,8 +977,6 @@ async def get_metadata(
     - If no `owner_username` is provided, return the metadata for the dataset if
       the caller is the owner of the dataset.
     """
-    assert userinfo.get("sub") is not None, "cannot resolve API key to user identity"
-    user_id = userinfo.get("sub")
 
     with Session(db()) as session:
         if owner_username:
@@ -1032,11 +1018,9 @@ async def get_metadata(
 # register update metadata route
 @dataset.put("/metadata/{dataset_name}")
 async def update_metadata(
-    dataset_name: str, request: Request, userinfo: Annotated[dict, Depends(APIIdentity)]
+    dataset_name: str, request: Request, user_id: Annotated[UUID, Depends(APIIdentity)]
 ):
     """Update metadata for a dataset. Only the owner of a dataset can update its metadata."""
-    assert userinfo.get("sub") is not None, "cannot resolve API key to user identity"
-    user_id = userinfo.get("sub")
 
     payload = await request.json()
     metadata = payload.get("metadata", {})

--- a/app-api/routes/dataset.py
+++ b/app-api/routes/dataset.py
@@ -1000,7 +1000,7 @@ async def get_metadata(
         else:
             dataset_response = load_dataset(
                 session,
-                by={"name": dataset_name, "user_id": uuid.UUID(user_id)},
+                by={"name": dataset_name, "user_id": user_id},
                 user_id=user_id,
                 allow_public=True,
                 return_user=False,

--- a/app-api/routes/dataset.py
+++ b/app-api/routes/dataset.py
@@ -480,7 +480,7 @@ async def delete_query(
     with Session(db()) as session:
         query = session.query(SavedQueries).filter(SavedQueries.id == query_id).first()
 
-        if str(query.user_id) != user_id:
+        if query.user_id != user_id:
             raise HTTPException(status_code=403, detail="Not allowed to delete query")
 
         session.delete(query)
@@ -841,7 +841,7 @@ async def create_policy(
             session, dataset_id, user_id, allow_public=True, return_user=False
         )
         # Only the owner of the dataset can create a policy for the dataset.
-        if str(dataset.user_id) != user_id:
+        if dataset.user_id != user_id:
             raise HTTPException(
                 status_code=403, detail="Not allowed to create policy for this dataset"
             )
@@ -891,7 +891,7 @@ async def update_policy(
             session, dataset_id, user_id, allow_public=True, return_user=False
         )
         # Only the owner of the dataset can update a policy for the dataset.
-        if str(dataset.user_id) != user_id:
+        if dataset.user_id != user_id:
             raise HTTPException(
                 status_code=403, detail="Not allowed to update policy for this dataset"
             )
@@ -944,7 +944,7 @@ async def delete_policy(
             session, dataset_id, user_id, allow_public=True, return_user=False
         )
         # Only the owner of the dataset can delete a policy for the dataset.
-        if str(dataset.user_id) != user_id:
+        if dataset.user_id != user_id:
             raise HTTPException(
                 status_code=403, detail="Not allowed to delete policy for this dataset"
             )
@@ -986,13 +986,13 @@ async def get_metadata(
             dataset_response = load_dataset(
                 session,
                 by={"name": dataset_name, "user_id": owner_user.id},
-                user_id=str(owner_user.id),
+                user_id=owner_user.id,
                 allow_public=True,
                 return_user=False,
             )
             # If the dataset is private and the caller is not the owner of the dataset,
             # return a 403.
-            if not dataset_response.is_public and user_id != str(owner_user.id):
+            if not dataset_response.is_public and user_id != owner_user.id:
                 raise HTTPException(
                     status_code=403,
                     detail="Not allowed to view metadata for this dataset",

--- a/app-api/routes/dataset_metadata.py
+++ b/app-api/routes/dataset_metadata.py
@@ -180,7 +180,7 @@ class ReadOnlyMetadataField(MetadataField):
     def update(self, metadata_dict: dict, new_value: Any|None, mode='incremental'):
         pass
     
-async def update_dataset_metadata(user_id: str, dataset_name: str, metadata: dict, replace_all: bool = False):
+async def update_dataset_metadata(user_id: UUID, dataset_name: str, metadata: dict, replace_all: bool = False):
     """
     Updates the metadata of a dataset.
 
@@ -217,7 +217,7 @@ async def update_dataset_metadata(user_id: str, dataset_name: str, metadata: dic
     with Session(db()) as session:
         dataset_response = load_dataset(
             session,
-            {"name": dataset_name, "user_id": uuid.UUID(user_id)},
+            {"name": dataset_name, "user_id": user_id},
             user_id,
             allow_public=True,
             return_user=False,

--- a/app-api/routes/dataset_metadata.py
+++ b/app-api/routes/dataset_metadata.py
@@ -1,47 +1,14 @@
 """Defines routes for APIs related to dataset metadata."""
 
-import datetime
-import json
-import os
-import re
-import uuid
-from enum import Enum
-from typing import Annotated, Any, Optional
+
+from typing import Any
 from uuid import UUID
 
-from cachetools import TTLCache, cached
-from fastapi import Depends, FastAPI, File, HTTPException, Request, UploadFile
-from fastapi.responses import StreamingResponse
-from models.datasets_and_traces import (
-    Annotation,
-    Dataset,
-    DatasetPolicy,
-    SavedQueries,
-    SharedLinks,
-    Trace,
-    User,
-    db,
-)
-from models.importers import import_jsonl
-from models.queries import (
-    dataset_to_json,
-    get_savedqueries,
-    load_annotations,
-    load_dataset,
-    query_traces,
-    search_term_mappings,
-    trace_to_exported_json,
-    trace_to_json,
-)
-from pydantic import ValidationError
-from routes.apikeys import APIIdentity
-from routes.auth import AuthenticatedUserIdentity, UserIdentity
-from sqlalchemy import and_, or_
-from sqlalchemy.exc import IntegrityError
+from fastapi import HTTPException
+from models.datasets_and_traces import db
+from models.queries import load_dataset
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
-from sqlalchemy.sql import exists, func
-from util.util import validate_dataset_name
 
 """
 A metadata field is a field in a datasets 'extra_metadata' dictionary that can be updated via the API. 

--- a/app-api/routes/push.py
+++ b/app-api/routes/push.py
@@ -26,7 +26,7 @@ Write-only API endpoint to push traces to the server.
 
 
 @push.post("/trace")
-async def push_trace(request: Request, user_id: Annotated[dict, Depends(APIIdentity)]):
+async def push_trace(request: Request, user_id: Annotated[uuid.UUID, Depends(APIIdentity)]):
 
 
     # extract payload

--- a/app-api/routes/trace.py
+++ b/app-api/routes/trace.py
@@ -49,7 +49,7 @@ async def get_image(
     user_id: Annotated[UUID | None, Depends(UserOrAPIIdentity)] = None,
 ):
     with Session(db()) as session:
-        trace = load_trace(
+        _ = load_trace(
             session, trace_id, user_id, allow_public=True, allow_shared=True
         )
 

--- a/app-api/routes/trace.py
+++ b/app-api/routes/trace.py
@@ -83,9 +83,8 @@ def get_trace_snippets(
 
 @trace.delete("/{id}")
 async def delete_trace(
-    id: str, userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)]
+    id: str, user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)]
 ):
-    user_id = userinfo["sub"]
 
     with Session(db()) as session:
         # can only delete own traces
@@ -154,10 +153,8 @@ async def download_trace(
 def get_trace_sharing(
     request: Request,
     id: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    _: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
-    # never None (always authenticated)
-    user_id = userinfo["sub"]
 
     with Session(db()) as session:
         return {"shared": has_link_sharing(session, id)}
@@ -167,10 +164,9 @@ def get_trace_sharing(
 def share_trace(
     request: Request,
     id: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
     # never None (always authenticated)
-    user_id = userinfo["sub"]
 
     with Session(db()) as session:
         # load trace to check for auth
@@ -195,9 +191,8 @@ def share_trace(
 def unshare_trace(
     request: Request,
     id: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
-    user_id = userinfo["sub"]
 
     with Session(db()) as session:
         trace = load_trace(session, id, user_id)  # load trace to check for auth
@@ -217,10 +212,8 @@ def unshare_trace(
 async def annotate_trace(
     request: Request,
     id: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
-    user_id = userinfo["sub"]
-
     with Session(db()) as session:
         trace = load_trace(
             session, id, user_id, allow_public=True, allow_shared=True
@@ -248,11 +241,10 @@ async def annotate_trace(
 async def replace_annotations(
     request: Request,
     id: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)]
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)]
 ):
     from sqlalchemy import String
 
-    user_id = userinfo["sub"]
 
     # payload will be {'source': 'annotation-source', 'annotations': [list of annotations]}
     payload = await request.json()
@@ -309,10 +301,9 @@ async def replace_annotations(
 # get all annotations of a trace
 @trace.get("/{id}/annotations")
 def get_annotations(
-    request: Request, id: str, userinfo: Annotated[dict, Depends(UserIdentity)]
+    request: Request, id: str, user_id: Annotated[UUID | None, Depends(UserIdentity)]
 ):
-    # may be None for anons
-    user_id = userinfo["sub"]
+    # user_id may be None for anons
 
     with Session(db()) as session:
         trace = load_trace(
@@ -327,9 +318,8 @@ def delete_annotation(
     request: Request,
     id: str,
     annotation_id: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
-    user_id = userinfo["sub"]
 
     with Session(db()) as session:
         trace = load_trace(
@@ -357,9 +347,8 @@ async def update_annotation(
     request: Request,
     id: str,
     annotation_id: str,
-    userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)],
+    user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)],
 ):
-    user_id = userinfo["sub"]
 
     with Session(db()) as session:
         trace = load_trace(
@@ -388,9 +377,8 @@ async def update_annotation(
 
 @trace.post("/snippets/new")
 async def upload_new_single_trace(
-    request: Request, userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)]
+    request: Request, user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)]
 ):
-    user_id = userinfo["sub"]
 
     with Session(db()) as session:
         payload = await request.json()

--- a/app-api/routes/trace.py
+++ b/app-api/routes/trace.py
@@ -73,7 +73,7 @@ def get_trace_snippets(
     with Session(db()) as session:
         traces = (
             session.query(Trace)
-            .filter(Trace.user_id == user_id, Trace.dataset_id == None)
+            .filter(Trace.user_id == user_id, Trace.dataset_id is None)
             .order_by(Trace.time_created.desc())
             .limit(limit)
             .all()
@@ -195,7 +195,7 @@ def unshare_trace(
 ):
 
     with Session(db()) as session:
-        trace = load_trace(session, id, user_id)  # load trace to check for auth
+        _ = load_trace(session, id, user_id)  # load trace to check for auth
         shared_link = (
             session.query(SharedLinks).filter(SharedLinks.trace_id == id).first()
         )
@@ -243,7 +243,6 @@ async def replace_annotations(
     id: str,
     user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)]
 ):
-    from sqlalchemy import String
 
 
     # payload will be {'source': 'annotation-source', 'annotations': [list of annotations]}
@@ -291,7 +290,7 @@ async def replace_annotations(
                 session.add(new_annotation)
 
             session.commit()
-    except Exception as e:
+    except Exception:
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail="An error occurred while updating annotations")
@@ -306,7 +305,7 @@ def get_annotations(
     # user_id may be None for anons
 
     with Session(db()) as session:
-        trace = load_trace(
+        _ = load_trace(
             session, id, user_id, allow_public=True, allow_shared=True
         )  # load trace to check for auth
         return [annotation_to_json(a, u) for a, u in load_annotations(session, id)]
@@ -322,7 +321,7 @@ def delete_annotation(
 ):
 
     with Session(db()) as session:
-        trace = load_trace(
+        _ = load_trace(
             session, id, user_id, allow_public=True, allow_shared=True
         )  # load trace to check for auth
         annotation = (
@@ -351,7 +350,7 @@ async def update_annotation(
 ):
 
     with Session(db()) as session:
-        trace = load_trace(
+        _ = load_trace(
             session, id, user_id, allow_public=True, allow_shared=True
         )  # load trace to check for auth
         annotation, user = (

--- a/app-api/routes/trace.py
+++ b/app-api/routes/trace.py
@@ -332,7 +332,7 @@ def delete_annotation(
         if annotation is None:
             raise HTTPException(status_code=404, detail="Annotation not found")
 
-        if str(annotation.user_id) != user_id:
+        if annotation.user_id != user_id:
             raise HTTPException(status_code=401, detail="Unauthorized delete")
 
         session.delete(annotation)
@@ -364,7 +364,7 @@ async def update_annotation(
         if annotation is None:
             raise HTTPException(status_code=404, detail="Annotation not found")
 
-        if str(annotation.user_id) != user_id:
+        if annotation.user_id != user_id:
             raise HTTPException(status_code=401, detail="Unauthorized delete")
 
         payload = await request.json()

--- a/app-api/routes/trace.py
+++ b/app-api/routes/trace.py
@@ -73,7 +73,7 @@ def get_trace_snippets(
     with Session(db()) as session:
         traces = (
             session.query(Trace)
-            .filter(Trace.user_id == user_id, Trace.dataset_id is None)
+            .filter(Trace.user_id == user_id, Trace.dataset_id == None)
             .order_by(Trace.time_created.desc())
             .limit(limit)
             .all()

--- a/app-api/routes/user.py
+++ b/app-api/routes/user.py
@@ -1,5 +1,5 @@
 from typing import Annotated
-
+from uuid import UUID
 from fastapi import Depends, FastAPI, Request
 from models.datasets_and_traces import Dataset, User, db, Annotation, Trace, SharedLinks
 from models.queries import save_user, user_to_json, dataset_to_json, annotation_to_json, trace_to_json
@@ -12,50 +12,63 @@ from routes.apikeys import APIIdentity
 user = FastAPI()
 
 
+def user_by_id(user_id: UUID) -> User | None:
+    with Session(db()) as session:
+        return session.query(User).filter(User.id == user_id).first()
+
+
 @user.get("/info")
-def get_user(userinfo: Annotated[dict, Depends(UserIdentity)]):
-    userid = userinfo["sub"]
+def get_user(request: Request, user_id: Annotated[UUID | None, Depends(UserIdentity)]):
     signedup = False
+    if user_id is not None:
+        session_user = user_by_id(user_id)
+        if session_user is None:
+            # stange edge condition where the user is not in the database
+            return {
+                "id": user_id,
+                "username": "unknown",
+                "signedUp": False,
+            }
 
-    if userid is not None:
-        with Session(db()) as session:
-            session_user = (
-                session.query(User).filter(User.id == userinfo["sub"]).first()
-            )
-            signedup = session_user is not None
+        user_info = user_to_json(session_user)
+        user_info["signedUp"] = True
+        user_info["name"] = request.state.userinfo["name"]
+        user_info["email"] = request.state.userinfo["email"]
+        return user_info
 
+    # anonymous user
     return {
-        "id": userinfo["sub"],
-        "username": userinfo["username"],
-        "email": userinfo["email"],
-        "name": userinfo["name"],
-        "image_url_hash": get_gravatar_hash(userinfo["email"]),
-        "signedUp": signedup,
+        "id": None,
+        "username": "unknown",
+        "email": "unknown",
+        "name": "unknown",
+        "image_url_hash": "unknown",
+        "signedUp": False,
     }
 
 
 @user.post("/signup")
 def signup(
-    request: Request, userinfo: Annotated[dict, Depends(AuthenticatedUserIdentity)]
+    request: Request, user_id: Annotated[UUID, Depends(AuthenticatedUserIdentity)]
 ):
     with Session(db()) as session:
-        save_user(session, userinfo)
+        save_user(session, request.state.userinfo)
         session.commit()
     return {"success": True}
 
 # to get the user identity for an API key, run
 # curl <INSTANCE_URL>/api/v1/user/identity -H "Authorization: Bearer <API_KEY>"
 @user.get("/identity")
-def identity(userinfo: Annotated[dict, Depends(APIIdentity)]):
+def identity(user_id: Annotated[UUID, Depends(APIIdentity)]):
+    user = user_by_id(user_id)
     return {
-        "username": userinfo["username"],
+        "username": user.username,
     }
 
 @user.get("/events")
 def events(
-    request: Request, userinfo: Annotated[dict, Depends(UserIdentity)], limit: int = 20
+    request: Request, user_id: Annotated[UUID | None, Depends(UserIdentity)], limit: int = 20
 ):
-    user_id = userinfo["sub"]
 
     # events are:
     # - public dataset is created

--- a/app-ui/server/auth.py
+++ b/app-ui/server/auth.py
@@ -9,6 +9,19 @@ import os
 from typing import Annotated
 from config import config
 
+DEVELOPER_USER = {
+    "sub": "3752ff38-da1a-4fa5-84a2-9e44a4b167ce",
+    "email": "dev@mail.com",
+    "username": "developer",
+    "name": "Developer"
+}
+DEVELOPER_USER2 = {
+    "sub": "3752ff38-da1a-4fa5-84a2-9e44a4b167ca",
+    "email": "dev2@mail.com",
+    "username": "developer2",
+    "name": "Developer2"
+}
+
 is_preview_deployment = os.getenv("PREVIEW") == "1"
 base_url = "https://" + os.getenv("APP_NAME") + ".invariantlabs.ai"
 client_id = config("authentication_client_id_prefix") + "-" + os.getenv("APP_NAME")
@@ -84,19 +97,9 @@ async def write_back_refreshed_token(request: Request, call_next):
 async def UserIdentity(request: Request):
     # check for DEV_MODE
     if os.getenv("DEV_MODE") == "true" and not "noauth" in request.headers.get("referer", []):
-        return {
-            "sub": "3752ff38-da1a-4fa5-84a2-9e44a4b167ce",
-            "email": "dev@mail.com",
-            "username": "developer",
-            "name": "Developer"
-        }
+        return DEVELOPER_USER
     if "noauth=user1" in request.headers.get("referer", []) and os.getenv("DEV_MODE") == "true":
-        return {
-            "sub": "3752ff38-da1a-4fa5-84a2-9e44a4b167ca",
-            "email": "dev2@mail.com",
-            "username": "developer2",
-            "name": "Developer2"
-        }
+        return DEVELOPER_USER2
 
     try:
         token = json.loads(request.cookies.get("jwt"))

--- a/app-ui/server/auth.py
+++ b/app-ui/server/auth.py
@@ -6,6 +6,7 @@ from urllib.parse import quote
 from fastapi import HTTPException
 from keycloak import KeycloakOpenID # pip require python-keycloak
 import os
+from uuid import UUID
 from typing import Annotated
 from config import config
 
@@ -140,7 +141,7 @@ async def UserIdentity(request: Request):
             "name": ''
         }
 
-async def AuthenticatedUserIdentity(identity: Annotated[dict, Depends(UserIdentity)]):
+async def AuthenticatedUserIdentity(identity: Annotated[UUID, Depends(UserIdentity)]):
     if identity["sub"] is None:
         raise HTTPException(status_code=401, detail="Unauthorized request")
     return identity


### PR DESCRIPTION
Cleanup on user authentication backend. Now an `user_id` is always retuned. For endpoint that don't require authentication it's None.
If more informations are needed (username, email, ...), they can be found under `request.state.userinfo`.