### PR TITLE
Increase padding around images in traces

### DIFF
--- a/app-ui/src/lib/traceview/plugins/image-viewer.scss
+++ b/app-ui/src/lib/traceview/plugins/image-viewer.scss
@@ -62,6 +62,7 @@ span.image-wrapper {
   pointer-events: none;
   border-radius: 2px;
   border-style: solid;
+  border-width: 1px;
   border-color: rgb(88 85 255);
 
   &.test-assertion-passed {

--- a/app-ui/src/lib/traceview/plugins/image-viewer.scss
+++ b/app-ui/src/lib/traceview/plugins/image-viewer.scss
@@ -6,8 +6,8 @@ img.trace-image {
 span.image-wrapper {
   display: inline-block;
   position: relative;
-  padding: 5px;
-  padding-right: 5px !important;
+  padding: 15px;
+  padding-right: 15px !important;
   max-width: 50%;
 }
 


### PR DESCRIPTION
This PR increases the padding around images in traces from 5px to 15px to provide better visual separation between images and surrounding content.

Changes:
- Increased general padding from 5px to 15px
- Increased right padding from 5px to 15px (with !important to ensure it takes precedence)

The changes maintain the max-width constraint of 50% to ensure images do not become too large.