### PR TITLE
Add badge for tool_name when message.role is tool. Also render tool outputs correctly for types other than string and objects.

### DIFF
--- a/app-ui/src/lib/traceview/traceview.tsx
+++ b/app-ui/src/lib/traceview/traceview.tsx
@@ -793,6 +793,13 @@ function string_color(s: string) {
 function CompactView(props: { message: any }) {
   // get first tool call or use message as tool call
   const message = props.message.message;
+  if (message.role === "tool" && message.tool_name) {
+    return (
+      <span className="badge" style={{ backgroundColor: string_color(message.tool_name) }}>
+        {message.tool_name}
+      </span>
+    );
+  }
   let tool_call = message.tool_calls ? message.tool_calls[0] : null;
   if (!message.role && message.type == "function") tool_call = message;
 
@@ -1003,12 +1010,14 @@ class MessageView extends React.Component<
                           this.props.onUpvoteDownvoteDelete
                         }
                       >
-                        {message.content.startsWith("local_base64_img:")
-                          ? message.content
-                          : truncate_content(
-                              message.content,
-                              config("truncation_limit")
-                            )}
+                        {typeof message.content === "string"
+                          ? message.content.startsWith("local_base64_img:")
+                            ? message.content
+                            : truncate_content(
+                                message.content,
+                                config("truncation_limit")
+                              )
+                          : message.content}
                       </Annotated>
                     )}
                   </div>
@@ -1092,17 +1101,9 @@ function formatJSONArray(props: {
 
       default:
         return (
-          <MessageJSONContent
-            content={item}
-            highlights={props.highlights.for_path("content")}
-            address={props.address + ".content"}
-            highlightContext={props.highlightContext}
-            message={props.message}
-            messages={props.messages}
-            traceIndex={props.traceIndex}
-            onUpvoteDownvoteCreate={props.onUpvoteDownvoteCreate}
-            onUpvoteDownvoteDelete={props.onUpvoteDownvoteDelete}
-          />
+          <Annotated {...props} address={address}>
+            {typeof item == "object" ? JSON.stringify(item) : item}
+          </Annotated>
         );
     }
   });


### PR DESCRIPTION
* Added a badge next to tool call outputs to display the tool name. 
* When tool output content was not of type string or object, we were not rendering the message correctly. Made it better. 

Tested with this trace: 

```
traces = [
    [
        {
            "role": "system",
            "content": "This the system instruction. Use the function call.",
        },
        {
            "role": "user",
            "content": [
                {"type": "text", "text": "Turn the lights down to a romantic level"}
            ],
        },
        {
            "role": "assistant",
            "tool_calls": [
                {
                    "type": "function",
                    "function": {
                        "name": "set_light_values",
                        "arguments": {"brightness": 20, "color_temp": "warm"},
                    },
                }
            ],
        },
        {
            "role": "tool",
            "tool_name": "set_light_values",
            "content": 176258992,
        },
        {
            "role": "tool",
            "tool_name": "set_light_values",
            "content": [
                1,
                2,
                3,
                "hello_world",
                {"a": "b", "c": [1, 2, "3"]},
                [1, 2, 3],
            ],
        },
        {
            "role": "tool",
            "tool_name": "set_light_values",
            "content": 5.7,
        },
        {
            "role": "tool",
            "tool_name": "set_light_values",
            "content": {
                "some": "object",
                "some_other": 1,
                "some_other_other": 2.3,
                "some_other_other_other": [1, 2, 3],
                "some_other_other_other_other": {"a": "b"},
            },
        },
        {
            "role": "user",
            "content": [
                {"type": "text", "text": "Set the lights to a romantic level"},
                {"type": "text", "text": "Set the lights to a some level"},
            ],
        },
        {
            "role": "assistant",
            "content": "OK. I've set the lights to a romantic level: 20% brightness and warm color temperature.\n",
        },
    ]
]
```

Output: 

<img width="580" alt="Screenshot 2025-03-11 at 11 22 50" src="https://github.com/user-attachments/assets/fa539e61-ee02-4ffe-9f00-38b31abd2b6f" />
