### PR TITLE
Unify guardrail actions and status into single selection

### DIFF
--- a/app-ui/src/pages/traces/Guardrails.tsx
+++ b/app-ui/src/pages/traces/Guardrails.tsx
@@ -113,21 +113,24 @@ function MutatePolicyModalContent(props) {
     {
       title: "Block Agent",
       description: "The agent is blocked from executing any further actions.",
-      value: "block",
+      value: "block-enabled",
+      actionValue: "block",
       icon: <BsBan />,
       enabled: true,
     },
     {
       title: "Log Failure",
       description: "The agent continues to execute but a failure is logged.",
-      value: "log",
+      value: "log-enabled",
+      actionValue: "log",
       icon: <BsCardList />,
       enabled: true,
     },
     {
       title: "Paused",
       description: "The guardrail is paused and is currently not checked.",
-      value: "log",
+      value: "log-paused",
+      actionValue: "log",
       icon: <BsPauseCircle />,
       enabled: false,
     },
@@ -251,14 +254,12 @@ function MutatePolicyModalContent(props) {
               <i>What to do when the guardrail is triggered.</i>
             </h3>
             <LabelSelect
-              value={guardrailEnabled ? guardrailAction : "paused"}
+              value={guardrailEnabled ? `${guardrailAction}-enabled` : "log-paused"}
               options={guardrailActions}
               onChange={(value) => {
-                const selectedAction = guardrailActions.find(a => 
-                  (value === "paused" && !a.enabled) || (value === a.value && a.enabled)
-                );
+                const selectedAction = guardrailActions.find(a => a.value === value);
                 if (selectedAction) {
-                  setGuardrailAction(selectedAction.value);
+                  setGuardrailAction(selectedAction.actionValue);
                   setGuardrailEnabled(selectedAction.enabled);
                 }
               }}

--- a/app-ui/src/pages/traces/Guardrails.tsx
+++ b/app-ui/src/pages/traces/Guardrails.tsx
@@ -128,7 +128,7 @@ function MutatePolicyModalContent(props) {
     },
     {
       title: "Paused",
-      description: "The guardrail is paused and is currently not checked.",
+      description: "The guardrail is paused and will not be checked.",
       value: "log-paused",
       actionValue: "log",
       icon: <BsPauseCircle />,

--- a/app-ui/src/pages/traces/Guardrails.tsx
+++ b/app-ui/src/pages/traces/Guardrails.tsx
@@ -115,12 +115,21 @@ function MutatePolicyModalContent(props) {
       description: "The agent is blocked from executing any further actions.",
       value: "block",
       icon: <BsBan />,
+      enabled: true,
     },
     {
       title: "Log Failure",
       description: "The agent continues to execute but a failure is logged.",
       value: "log",
       icon: <BsCardList />,
+      enabled: true,
+    },
+    {
+      title: "Paused",
+      description: "The guardrail is paused and is currently not checked.",
+      value: "log",
+      icon: <BsPauseCircle />,
+      enabled: false,
     },
   ];
 
@@ -171,7 +180,6 @@ function MutatePolicyModalContent(props) {
           {!editMode && (
             <>
               <BsDatabaseLock /> Guardrail Details
-              {guardrailEnabled && <span className="badge live">LIVE</span>}
               {error && <span className="error">Error: {error}</span>}
             </>
           )}
@@ -239,37 +247,21 @@ function MutatePolicyModalContent(props) {
               className="policy-name"
             />
             <h3>
-              Status
-              <i>Paused guardrails will not be checked.</i>
-            </h3>
-            <LabelSelect
-              value={guardrailEnabled}
-              options={[
-                {
-                  title: "Enabled",
-                  description:
-                    "The guardrail is enabled and will be checked during agent execution.",
-                  value: true,
-                  icon: <BsShieldFillCheck />,
-                },
-                {
-                  title: "Paused",
-                  description:
-                    "The guardrail is paused and is currently not checked.",
-                  value: false,
-                  icon: <BsPauseCircle />,
-                },
-              ]}
-              onChange={(value) => setGuardrailEnabled(value)}
-            />
-            <h3>
               Action
               <i>What to do when the guardrail is triggered.</i>
             </h3>
             <LabelSelect
-              value={guardrailAction}
+              value={guardrailEnabled ? guardrailAction : "paused"}
               options={guardrailActions}
-              onChange={(value) => setGuardrailAction(value)}
+              onChange={(value) => {
+                const selectedAction = guardrailActions.find(a => 
+                  (value === "paused" && !a.enabled) || (value === a.value && a.enabled)
+                );
+                if (selectedAction) {
+                  setGuardrailAction(selectedAction.value);
+                  setGuardrailEnabled(selectedAction.enabled);
+                }
+              }}
             />
           </div>
         )}


### PR DESCRIPTION
This PR simplifies the guardrail UI by combining the enabled/paused status with the action selection. Instead of having a separate section for enabled/paused status, users can now select from three options at the same level:

- Block Agent (enabled=true, action=block)
- Log Failure (enabled=true, action=log)
- Paused (enabled=false, action=log)

Changes:
- Combined enabled/paused status with action selection
- Added Paused option at same level as Block and Log
- Removed redundant LIVE badge
- Maintained internal action and enabled state based on selection

This change makes the UI more intuitive and reduces the number of decisions users need to make when configuring guardrails.