### PR TITLE
Add alembic migration to add a postgres sequence for the trace index column.

### DIFF
--- a/app-api/database/versions/83097c7e026b_migrate_dataset_level_trace_index_to_.py
+++ b/app-api/database/versions/83097c7e026b_migrate_dataset_level_trace_index_to_.py
@@ -1,0 +1,130 @@
+"""Migrate dataset level trace index to sequences
+
+Revision ID: 83097c7e026b
+Revises: 1824436b3cf9
+Create Date: 2025-03-11 16:24:53.276229
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "83097c7e026b"
+down_revision: Union[str, None] = "1824436b3cf9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    # Step 1: Get all dataset_id values (casted as TEXT since they are UUIDs)
+    dataset_ids = connection.execute(
+        sa.text(
+            "SELECT DISTINCT dataset_id::TEXT FROM traces WHERE dataset_id IS NOT NULL"
+        )
+    ).fetchall()
+
+    # Step 2: Create a sequence for each dataset_id and set it to start at MAX(index) + 1
+    for (dataset_id,) in dataset_ids:
+        max_index = connection.execute(
+            sa.text(
+                "SELECT COALESCE(MAX(index), -1) FROM traces WHERE dataset_id = :dataset_id"
+            ),
+            {"dataset_id": dataset_id},
+        ).scalar()
+        next_index = max_index + 1
+
+        sequence_name = f"dataset_seq_{dataset_id.replace('-', '_')}"
+
+        # Drop the sequence if it already exists (to avoid conflicts)
+        connection.execute(sa.text(f"DROP SEQUENCE IF EXISTS {sequence_name}"))
+
+        # Create a new sequence starting from the next index
+        connection.execute(
+            sa.text(
+                f"CREATE SEQUENCE {sequence_name} START WITH {next_index} MINVALUE 0"
+            )
+        )
+
+    # Step 3: Create the trigger function
+    connection.execute(
+        sa.text("""
+    CREATE OR REPLACE FUNCTION set_trace_index() RETURNS TRIGGER AS $$
+    DECLARE
+        seq_name TEXT;
+        new_index INTEGER;
+        start_index INTEGER;
+    BEGIN
+        -- Only assign index via the sequence if dataset_id is NOT NULL and index is NULL
+        IF NEW.dataset_id IS NOT NULL AND NEW.index is NULL THEN
+            -- Generate a unique sequence name for this dataset_id
+            seq_name := 'dataset_seq_' || replace(NEW.dataset_id::TEXT, '-', '_');
+
+            -- Try to get the next value; if the sequence does not exist, create it
+            BEGIN
+                EXECUTE format('SELECT nextval(''%s'')', seq_name) INTO new_index;
+            EXCEPTION
+                WHEN undefined_table THEN
+                    -- Calculate start value based on the current max index
+                    -- If there are no traces, start at 0
+                    -- Otherwise, start at the current max index + 1
+                    -- This is possible when a jsonl file is uploaded with indices
+                    SELECT COALESCE(MAX(index), -1) + 1 INTO start_index FROM traces WHERE dataset_id = NEW.dataset_id;
+
+                    EXECUTE format('CREATE SEQUENCE %I START WITH %s MINVALUE 0', seq_name, start_index);
+                    EXECUTE format('SELECT nextval(''%s'')', seq_name) INTO new_index;
+            END;
+
+            -- Set the computed index
+            NEW.index := new_index;
+        ELSIF NEW.dataset_id IS NULL THEN
+            NEW.index := 0;
+        END IF;
+
+        -- Ensure 'name' is set correctly
+        IF NEW.name IS NULL OR NEW.name = '' THEN
+            NEW.name := 'Run ' || COALESCE(NEW.index, 0);
+        END IF;
+
+        RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+    )
+
+    # Step 4: Create the trigger
+    connection.execute(
+        sa.text("""
+    CREATE TRIGGER trigger_set_trace_index
+    BEFORE INSERT ON traces
+    FOR EACH ROW
+    EXECUTE FUNCTION set_trace_index();
+    """)
+    )
+
+
+def downgrade():
+    connection = op.get_bind()
+
+    # Step 1: Drop the trigger
+    connection.execute(
+        sa.text("DROP TRIGGER IF EXISTS trigger_set_trace_index ON traces;")
+    )
+
+    # Step 2: Drop the trigger function
+    connection.execute(sa.text("DROP FUNCTION IF EXISTS set_trace_index;"))
+
+    # Step 3: Drop all dataset sequences
+    dataset_ids = connection.execute(
+        sa.text(
+            "SELECT DISTINCT dataset_id::TEXT FROM traces WHERE dataset_id IS NOT NULL"
+        )
+    ).fetchall()
+
+    for (dataset_id,) in dataset_ids:
+        sequence_name = f"dataset_seq_{dataset_id.replace('-', '_')}"
+        connection.execute(sa.text(f"DROP SEQUENCE IF EXISTS {sequence_name}"))

--- a/app-api/routes/dataset.py
+++ b/app-api/routes/dataset.py
@@ -51,7 +51,7 @@ from models.analyzer_model import JobRequest, AnalysisRequest
 from pydantic import ValidationError
 from routes.apikeys import APIIdentity, UserOrAPIIdentity
 from routes.auth import AuthenticatedUserIdentity, UserIdentity
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, or_, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
@@ -321,6 +321,10 @@ async def delete_dataset(
 
         # delete dataset
         session.delete(dataset)
+
+        # delete the trace index sequence for the dataset (if it exists)
+        sequence_name = f"dataset_seq_{str(dataset.id).replace('-', '_')}"
+        session.execute(text(f"DROP SEQUENCE IF EXISTS {sequence_name}"))
 
         session.commit()
 

--- a/app-api/routes/trace.py
+++ b/app-api/routes/trace.py
@@ -445,7 +445,6 @@ async def upload_new_single_trace(
         trace = Trace(
             id=trace_id,
             dataset_id=None,
-            index=0,
             user_id=user_id,
             content=message_content,
             extra_metadata=extra_metadata,

--- a/tests/test-sdk/test_push_trace.py
+++ b/tests/test-sdk/test_push_trace.py
@@ -1,5 +1,6 @@
 """Tests for the push trace API via SDK."""
 
+import asyncio
 import os
 import sys
 import uuid
@@ -321,6 +322,69 @@ async def test_create_request_and_push_trace_while_creating_dataset(
 
     # Clean up the dataset created.
     dataset_id = trace_1["dataset"]
+    dataset_delete_response = await context.request.delete(
+        f"{url}/api/v1/dataset/byid/{dataset_id}"
+    )
+    await expect(dataset_delete_response).to_be_ok()
+
+
+async def test_push_multiple_traces_in_parallel_to_same_dataset(
+    context, url, async_invariant_client
+):
+    """Test that push_traces works correctly when we push multiple traces in parallel."""
+    dataset_name = "test_dataset" + str(uuid.uuid4())
+    number_requests = 50  # Number of traces to push in parallel
+
+    async def push_trace(i):
+        try:
+            response = await async_invariant_client.create_request_and_push_trace(
+                messages=[
+                    [
+                        {"role": "user", "content": f"request: {str(i)}"},
+                        {"role": "assistant", "content": f"response: {str(i)}"},
+                    ]
+                ],
+                dataset=dataset_name,
+            )
+            return response.id[0]
+        except Exception as _:
+            return None
+
+    # Run all tasks in parallel
+    trace_ids = await asyncio.gather(*[push_trace(i) for i in range(number_requests)])
+
+    trace_ids = [t for t in trace_ids if t is not None]
+    assert len(trace_ids) == number_requests, "Some push trace requests failed"
+
+    trace_indices = []
+    trace_names = []
+    trace_user_contents = []
+    trace_assistant_contents = []
+
+    dataset_id = None
+    for trace_id in trace_ids:
+        trace_response = await context.request.get(f"{url}/api/v1/trace/{trace_id}")
+        await expect(trace_response).to_be_ok()
+        trace = await trace_response.json()
+        trace_indices.append(trace["index"])
+        trace_names.append(trace["name"])
+        trace_user_contents.append(trace["messages"][0]["content"])
+        trace_assistant_contents.append(trace["messages"][1]["content"])
+        if dataset_id is None:
+            dataset_id = trace["dataset"]
+        else:
+            assert (
+                dataset_id == trace["dataset"]
+            ), "All traces should belong to same dataset"
+
+    assert set(trace_indices) == set(range(number_requests))
+    assert set(trace_names) == {f"Run {i}" for i in range(number_requests)}
+    assert set(trace_user_contents) == {f"request: {i}" for i in range(number_requests)}
+    assert set(trace_assistant_contents) == {
+        f"response: {i}" for i in range(number_requests)
+    }
+
+    # Clean up the dataset created.
     dataset_delete_response = await context.request.delete(
         f"{url}/api/v1/dataset/byid/{dataset_id}"
     )

--- a/tests/test-ui-api/test_import_export.py
+++ b/tests/test-ui-api/test_import_export.py
@@ -86,13 +86,46 @@ async def test_upload_and_delete_dataset(dataset_name, url, context, delete_by):
 
 
 async def test_upload_data(dataset_name, url, context, data_webarena_with_metadata):
-    response = await upload_dataset_file(
+    dataset_upload_response = await upload_dataset_file(
         context, url, dataset_name, data_webarena_with_metadata.encode("utf-8")
     )
-    await expect(response).to_be_ok()
-    returned_object = await response.json()
-    assert returned_object["name"] == dataset_name
-    await util.async_delete_dataset_by_id(url, context, returned_object["id"])
+    await expect(dataset_upload_response).to_be_ok()
+    dataset = await dataset_upload_response.json()
+    assert dataset["name"] == dataset_name
+
+    # Verify metadata.
+    assert (
+        dataset["extra_metadata"]["description"]
+        == "Traces collected from WebArena Step agent"
+    )
+
+    # Verify the traces.
+    traces_lookup_response = await context.request.get(
+        url + f'/api/v1/dataset/byid/{dataset["id"]}/traces'
+    )
+    await expect(traces_lookup_response).to_be_ok()
+    traces_created = await traces_lookup_response.json()
+    assert len(traces_created) == 2
+    trace_1 = next(
+        (
+            trace
+            for trace in traces_created
+            if trace["index"] == 0 and trace["name"] == "Run 0"
+        ),
+        None,
+    )
+    trace_2 = next(
+        (
+            trace
+            for trace in traces_created
+            if trace["index"] == 1 and trace["name"] == "Run 1"
+        ),
+        None,
+    )
+    assert trace_1 is not None
+    assert trace_2 is not None
+
+    await util.async_delete_dataset_by_id(url, context, dataset["id"])
 
 
 async def test_reupload_dataset_with_same_name_fails(
@@ -244,6 +277,35 @@ async def test_upload_dataset_where_correct_indices_are_present(
     assert trace_2["extra_metadata"]["success"] is False
     assert trace_1["extra_metadata"]["task_id"] == 5
     assert trace_2["extra_metadata"]["task_id"] == 812
+
+    # Push another trace to this dataset
+    trace_creation_response = await context.request.post(
+        url + "/api/v1/push/trace",
+        data={
+            "messages": [
+                [
+                    {"role": "user", "content": "Hello!"},
+                    {"role": "assistant", "content": "hello back to you"},
+                ]
+            ],
+            "dataset": dataset_created["name"],
+        },
+    )
+
+    await expect(trace_creation_response).to_be_ok()
+    trace_id = (await trace_creation_response.json())["id"][0]
+
+    # Lookup the new trace
+    trace_lookup_response = await context.request.get(url + f"/api/v1/trace/{trace_id}")
+    await expect(trace_lookup_response).to_be_ok()
+    trace_response = await trace_lookup_response.json()
+    # The index should be 812 + 1 = 813
+    assert trace_response["index"] == 813
+    assert trace_response["name"] == "Run 813"
+    assert trace_response["messages"] == [
+        {"role": "user", "content": "Hello!"},
+        {"role": "assistant", "content": "hello back to you"},
+    ]
 
     # Delete the dataset.
     await util.async_delete_dataset_by_id(url, context, dataset_created["id"])

--- a/tests/test-ui/test_basic.py
+++ b/tests/test-ui/test_basic.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import time
 
 # add tests folder (parent) to sys.path
 import sys
@@ -197,8 +196,8 @@ async def test_create_empty_dataset_and_then_upload_file(
         await page.get_by_label("Upload").click()
 
     # verify that the traces are shown
+    await page.wait_for_selector("text=Run 0")
     await page.wait_for_selector("text=Run 1")
-    await page.wait_for_selector("text=Run 2")
     await screenshot(page)
 
     # delete dataset


### PR DESCRIPTION
* For a snippet, the index is 0, and the dataset_id column is NULL in the trace row.

* The PostgreSQL sequence for the index starts at 0 for an empty dataset. As we push traces into it, the index increases by 1 each time. The first trace pushed has an index of 0, the second one has an index of 1, and so on.

* If we upload a dataset file containing indices, we verify that each trace has an index field and that all indices are unique. In this case, a PostgreSQL sequence is not created, and the provided indices are used as is. Later, if we push a new trace to this dataset, a PostgreSQL sequence is created, starting at max(current indices for this dataset) + 1.

* For dataset file uploads, if no index exists in the file, we simply initialize a sequence starting from 0. Previously, this was set to 1.