### PR TITLE
Fix/bug parse severity

### DIFF
--- a/app-api/models/analyzer_model.py
+++ b/app-api/models/analyzer_model.py
@@ -9,7 +9,7 @@ from typing import Literal
 class Annotation(BaseModel):
     content: str
     location: str | None = None
-    severity: float
+    severity: float | None
 
 
 class Sample(BaseModel):

--- a/app-api/models/queries.py
+++ b/app-api/models/queries.py
@@ -135,7 +135,7 @@ class AnalyzerTraceExporter:
                     and annotation.extra_metadata.get("source") == "analyzer-model"
                 ):
                     continue
-                if AnalyzerTraceExporter.is_annotation_for_analyzer(annotation.content):
+                if not AnalyzerTraceExporter.is_annotation_for_analyzer(annotation.content):
                     continue
                 content, severity = AnalyzerTraceExporter.get_content_severity(annotation.content)
                 samples_by_id[str(trace.id)].annotations.append(

--- a/app-api/models/queries.py
+++ b/app-api/models/queries.py
@@ -71,6 +71,20 @@ class AnalyzerTraceExporter:
         self.dataset_id = dataset_id
         self.dataset_name = dataset_name
 
+    @classmethod
+    def is_annotation_for_analyzer(cls, content: str) -> bool:
+        return bool(re.search(r"\[.*\]", content))
+
+    @classmethod
+    def get_content_severity(cls, content: str) -> tuple[str, float]:
+        match = re.search(r"severity=([0-1](?:\.\d+)?)", content)  # Matches severity values from 0 to 1
+        if match:
+            severity = float(match.group(1))
+            content = re.sub(r",?\s*severity=[0-1](?:\.\d+)?", "", content).strip()
+            return content, severity
+        return content, None # Return original string with severity=None if not found
+            
+
     async def analyzer_model_input(
         self, session: Session, input_trace_id: UUID | None = None
     ) -> tuple[list[AnalyzerInputSample], list[AnalyzerSample]]:
@@ -121,15 +135,14 @@ class AnalyzerTraceExporter:
                     and annotation.extra_metadata.get("source") == "analyzer-model"
                 ):
                     continue
+                if AnalyzerTraceExporter.is_annotation_for_analyzer(annotation.content):
+                    continue
+                content, severity = AnalyzerTraceExporter.get_content_severity(annotation.content)
                 samples_by_id[str(trace.id)].annotations.append(
                     AnalyzerAnnotation(
-                        content=annotation.content,
+                        content=content,
                         location=annotation.address,
-                        severity=float(
-                            annotation.extra_metadata.get("severity", 0.0)
-                            if annotation.extra_metadata
-                            else 0.0
-                        ),
+                        severity=severity,
                     )
                 )
             if input_trace_id:


### PR DESCRIPTION
Now I only annotations containing `[` and `]` are sent to the analyzer. Severity is now also correctly parsed