### PR TITLE
Split analyzer model annotations

### DIFF
--- a/app-api/models/queries.py
+++ b/app-api/models/queries.py
@@ -339,7 +339,9 @@ def get_all_jobs(session: Session) -> List[DatasetJob]:
 
 # TODO: Fix typo in the function name
 def load_annotations(session: Session, by):
+    print(by, "by")
     query_filter = get_query_filter(by, Annotation, User, default_key="trace_id")
+    print(query_filter, "query_filter")
     return (
         session.query(Annotation, User)
         .filter(query_filter)

--- a/app-api/models/queries.py
+++ b/app-api/models/queries.py
@@ -339,9 +339,7 @@ def get_all_jobs(session: Session) -> List[DatasetJob]:
 
 # TODO: Fix typo in the function name
 def load_annotations(session: Session, by):
-    print(by, "by")
     query_filter = get_query_filter(by, Annotation, User, default_key="trace_id")
-    print(query_filter, "query_filter")
     return (
         session.query(Annotation, User)
         .filter(query_filter)

--- a/app-api/routes/dataset.py
+++ b/app-api/routes/dataset.py
@@ -714,7 +714,6 @@ async def download_traces_as_analyzer_input(
     Download the dataset in JSONL format.
     """
     with Session(db()) as session:
-        print("akuwerwergdf")
         # Check if the user has access to the dataset
         try:
             id = UUID(id)
@@ -726,7 +725,6 @@ async def download_traces_as_analyzer_input(
         if dataset.user_id != user_id:
             raise HTTPException(status_code=403, detail="Access denied")
 
-        print("there")
         user = session.query(User).filter(User.id == dataset.user_id).first()
         if not user:
             raise HTTPException(status_code=404, detail="User not found")

--- a/app-api/routes/dataset.py
+++ b/app-api/routes/dataset.py
@@ -652,7 +652,7 @@ def get_traces(
                     .filter(
                         ~func.coalesce(
                             Annotation.extra_metadata.op("->>")("source"), ""
-                        ).in_(["analyzer-model", "analyzer"])
+                        ).in_(["analyzer-model", "analyzer", "test-assertion", "test-assertion-passed", "test-expectation", "test-expectation-passed"])
                     )
                     .label("num_line_annotations"),
                 )

--- a/app-api/routes/jobs.py
+++ b/app-api/routes/jobs.py
@@ -231,10 +231,10 @@ async def on_analysis_result(job: DatasetJob, results: CompleatedJobResponse):
                 source,
                 [
                     {
-                        "content": json.dumps(analysis.model_dump(exclude={"cost", "id"})["annotations"]),
-                        "address": "<root>",
-                        "extra_metadata": {"source": source},
-                    }
+                        "content": annotation.content,
+                        "address": annotation.location,
+                        "extra_metadata": {"source": source, "severity": annotation.severity},
+                    } for annotation in analysis.annotations
                 ],
             )
         cost = sum(a.cost for a in results.analysis if a.cost is not None)

--- a/app-api/routes/trace.py
+++ b/app-api/routes/trace.py
@@ -294,11 +294,6 @@ async def analyze_trace(
                     annotation = annotation_from_chunk(chunk)
                     if isinstance(annotation, AnalyzerAnnotation):
                         with Session(db()) as session:
-                            print("new_annotation", {
-                                "content": annotation.content,
-                                "location": annotation.location,
-                                "severity": annotation.severity,
-                            })
                             new_annotation = Annotation(
                                 trace_id=UUID(id),
                                 user_id=user_id,
@@ -578,7 +573,6 @@ async def append_messages(
                         "Expected format: ISO 8601, e.g., 2025-01-23T10:30:00+00:00"
                     ),
                 ) from e
-    print("new messages", new_messages)
     try:
         with Session(db()) as session:
             with session.begin():  # Start transaction
@@ -596,7 +590,6 @@ async def append_messages(
                 timestamp_for_new_messages = datetime.now(timezone.utc).isoformat()
                 for message in new_messages:
                     message.setdefault("timestamp", timestamp_for_new_messages)
-                print("here", new_messages)
                 dataset_name = "!ROOT_DATASET_FOR_SNIPPETS"
                 if trace_response.dataset_id:
                     dataset_response = (

--- a/app-ui/src/lib/traceview/TraceView.scss
+++ b/app-ui/src/lib/traceview/TraceView.scss
@@ -395,13 +395,13 @@ body {
     position: relative;
     cursor: pointer;
 
-    svg {
+    >svg {
       display: inline-block;
       position: relative;
       margin-right: 2pt;
     }
 
-    svg:last-of-type {
+    >svg:last-of-type {
       margin-right: 3pt;
     }
 
@@ -863,7 +863,6 @@ pre.marked-line {
   margin-left: 5pt;
 }
 
-.annotation-indicator,
 .tool-call-badge,
 .badge {
   font-family:
@@ -895,19 +894,6 @@ pre.marked-line {
   color: rgba(37, 36, 99, 0.761);
   transition: opacity 0.1s;
 
-  &.human {
-    border: 1pt solid rgba(88, 85, 246, 0.2);
-    background-color: rgba(88, 85, 246, 0.2);
-    position: absolute;
-    left: -12.5pt;
-    transform: translateX(-100%) scale(1);
-    opacity: 0.8;
-
-    &:hover {
-      opacity: 1;
-    }
-  }
-
   svg {
     position: relative;
     left: 0.5pt !important;
@@ -916,12 +902,33 @@ pre.marked-line {
     overflow: visible;
   }
 }
-
+.annotation-indicator{
+  height: 18pt;
+  line-height: 18pt;
+  padding-left: 4pt;
+  padding-right: 4pt;
+  padding-top: 1pt;
+  font-size: 10pt;
+  font-weight: bold;
+  text-align: center;
+  align-items: bottom;
+  margin-left: 4pt;
+  background-color: rgba(88, 85, 246, 0.2);
+  border-radius: 2.5pt;
+  color: rgba(37, 36, 99, 0.761);
+}
+.message-header.role .annotation-indicator{
+  font-size: 7pt;
+  height: 12pt;
+  padding-top: 0pt;
+  line-height: 12pt;
+  padding-left: 3pt;
+  padding-right: 3pt;
+}
 .tool-call-badge {
   color: rgba(0, 0, 0, 0.627);
 }
 
-.sidebar .annotation-indicator,
 .badge {
   margin-top: 1pt;
   height: 18pt;
@@ -936,17 +943,6 @@ pre.marked-line {
   background-color: rgba(88, 85, 246, 0.2);
   border-radius: 2.5pt;
   color: rgba(37, 36, 99, 0.761);
-  &.user {
-    background-color: rgba(88, 85, 246, 0.2);
-    color: rgba(37, 36, 99, 0.761);
-  } 
-  &.analyzer-model{
-    background-color: rgba(87, 87, 87, 0.2);
-    color: rgba(37, 37, 36, 0.761);
-  }
-  &.guardrails-error{
-    background-color: rgba(249, 137, 0, 0.596);
-  }
 }
 
 .message-header {

--- a/app-ui/src/lib/traceview/TraceView.scss
+++ b/app-ui/src/lib/traceview/TraceView.scss
@@ -395,13 +395,13 @@ body {
     position: relative;
     cursor: pointer;
 
-    >svg {
+    > svg {
       display: inline-block;
       position: relative;
       margin-right: 2pt;
     }
 
-    >svg:last-of-type {
+    > svg:last-of-type {
       margin-right: 3pt;
     }
 
@@ -902,7 +902,7 @@ pre.marked-line {
     overflow: visible;
   }
 }
-.annotation-indicator{
+.annotation-indicator {
   height: 18pt;
   line-height: 18pt;
   padding-left: 4pt;
@@ -917,27 +917,39 @@ pre.marked-line {
   border-radius: 2.5pt;
   color: rgba(37, 36, 99, 0.761);
 }
-.message-header.role .annotation-indicator{
+
+.message-header.role .annotation-indicator {
   font-size: 7pt;
   height: 12pt;
-  padding-top: 0pt;
+  padding-top: 0.5pt;
   line-height: 12pt;
   padding-left: 3pt;
   padding-right: 3pt;
+
+  svg {
+    position: relative;
+    top: 0.5pt;
+  }
 }
-.options .annotation-indicator{
+
+.options .annotation-indicator {
   padding-left: 4pt;
   padding-right: 4pt;
   padding-top: 3pt;
   padding-bottom: 3pt;
   font-size: 14pt;
 }
-.options .radio-block{
-  border-bottom: 1pt solid rgb(234, 234, 234);
 
+.options .radio-block {
+  border-bottom: 1pt solid rgb(234, 234, 234);
 }
+
 .tool-call-badge {
   color: rgba(0, 0, 0, 0.627);
+
+  svg {
+    margin-right: 4pt;
+  }
 }
 
 .badge {

--- a/app-ui/src/lib/traceview/TraceView.scss
+++ b/app-ui/src/lib/traceview/TraceView.scss
@@ -925,6 +925,17 @@ pre.marked-line {
   padding-left: 3pt;
   padding-right: 3pt;
 }
+.options .annotation-indicator{
+  padding-left: 4pt;
+  padding-right: 4pt;
+  padding-top: 3pt;
+  padding-bottom: 3pt;
+  font-size: 14pt;
+}
+.options .radio-block{
+  border-bottom: 1pt solid rgb(234, 234, 234);
+
+}
 .tool-call-badge {
   color: rgba(0, 0, 0, 0.627);
 }

--- a/app-ui/src/lib/traceview/TraceView.scss
+++ b/app-ui/src/lib/traceview/TraceView.scss
@@ -936,6 +936,17 @@ pre.marked-line {
   background-color: rgba(88, 85, 246, 0.2);
   border-radius: 2.5pt;
   color: rgba(37, 36, 99, 0.761);
+  &.user {
+    background-color: rgba(88, 85, 246, 0.2);
+    color: rgba(37, 36, 99, 0.761);
+  } 
+  &.analyzer-model{
+    background-color: rgba(87, 87, 87, 0.2);
+    color: rgba(37, 37, 36, 0.761);
+  }
+  &.guardrails-error{
+    background-color: rgba(249, 137, 0, 0.596);
+  }
 }
 
 .message-header {

--- a/app-ui/src/lib/traceview/highlights.ts
+++ b/app-ui/src/lib/traceview/highlights.ts
@@ -94,7 +94,7 @@ export class HighlightedJSON {
       return EMPTY_ANNOTATIONS;
     }
 
-    if (this.cachedSubs[path]) {
+    if (this.cachedSubs[path]) {  
       return this.cachedSubs[path];
     }
 

--- a/app-ui/src/lib/traceview/highlights.ts
+++ b/app-ui/src/lib/traceview/highlights.ts
@@ -13,6 +13,15 @@ export interface HighlightData {
   id?: string
 }
 
+/** A single annotation, with a source, content, address, and id. */
+export interface AnalyzerAnnotation {
+  source: "analyzer-model"; // Restricts `source` to only this value
+  content: any;
+  address: string;
+  severity: number | null;
+  id: string;
+}
+
 /** A single highlight, with a start and end offset in the source text or leaf string, and a content field. */
 export interface Highlight extends HighlightData {
   start: number;

--- a/app-ui/src/lib/traceview/traceview.tsx
+++ b/app-ui/src/lib/traceview/traceview.tsx
@@ -10,6 +10,7 @@ import {
   BsExclamationCircleFill,
   BsPencilFill,
   BsFileEarmarkBreak,
+  BsDatabaseLock,
 } from "react-icons/bs";
 
 import { HighlightedJSON, Highlight, GroupedHighlight } from "./highlights";
@@ -759,12 +760,12 @@ function MessageHeader(props: {
       {props.expanded ? <BsCaretRightFill /> : <BsCaretDownFill />}
       <RoleIcon role={props.role} />
       {props.role}
-      <CompactView message={props} />
       <MessageHeaderAnnotationIndicator
         highlightContext={props.highlightContext}
         address={props.address}
         message={props.message}
       />
+      <CompactView message={props} />
       <div
         className="address"
         onClick={(e) => {
@@ -780,33 +781,33 @@ function MessageHeader(props: {
 }
 
 /**
- * The written name of the annotation type, e.g. "human" or "highlight".
+ * The written name of the annotation type, e.g. "user" or "highlight".
  *
  * Can be empty if the type should not have a descriptive name in the UI.
  */
 function annotationName(type: string) {
-  if (type === "human") {
-    return "";
-  } else {
-    // other types do not have an explicit name
-    return "highlight";
-  }
+  return type
 }
 
 function annotationIcon(type: string) {
-  if (type === "human") {
-    return <BsPencilFill />;
-  } else {
+  if (type === "user") {
+    return <BsPencilFill style={{ transform: 'scale(0.9)', transformOrigin: 'bottom' }}/>;
+  } 
+  if (type === "analyzer-model") {
     // other types do not have an explicit icon
     return <BsFileEarmarkBreak />;
   }
+  if (type === "guardrails-error" || type === "analyzer") {
+    return <BsDatabaseLock />;
+  }
+  return "ciao"
 }
 
 /**
  * Shows badges in the message header, if the message has highlights or
  * user annotations. Also visible in the collapsed view.
  *
- * 'human', i.e. user, annotations are shown offset to the left of the header, not in the header.
+ * 'user', i.e. user, annotations are shown offset to the left of the header, not in the header.
  *
  * @param props.highlightContext The context for the highlights.
  * @param props.address The address of the message.
@@ -833,9 +834,10 @@ function MessageHeaderAnnotationIndicator(props: {
     <>
       {annotationTypes.map((type, index) => {
         return (
-          <span
-            key={index}
-            className={"annotation-indicator " + type.type}
+          <AnnotationCounterBadge 
+            key={index} 
+            count={type.count} 
+            type={type.type} 
             onClick={() => {
               if (type.address) {
                 reveal(type.address, "annotations", true, {
@@ -843,16 +845,26 @@ function MessageHeaderAnnotationIndicator(props: {
                 });
               }
             }}
-          >
-            {annotationIcon(type.type)}
-            {type.count} {annotationName(type.type)}
-            {annotationName(type.type) != "" && type.count > 1 ? "s" : ""}
-          </span>
+          />
         );
       })}
     </>
   );
 }
+
+// bedge component
+export function AnnotationCounterBadge(props: { count: number; type: string ; onClick?: () => void }) {
+
+  const name = annotationName(props.type);
+  const tooltip = (props.count > 1 ? props.count + " ": "") + name + " annotation" + (props.count > 1 ? "s" : "");
+  return (
+    <span className={"annotation-indicator"} onClick={props.onClick} data-tooltip-id="highlight-tooltip" data-tooltip-content={tooltip}>
+      {annotationIcon(props.type)}
+      {props.count > 1 ? <span className="count"> {props.count}</span> : null}
+    </span>
+  );
+}
+
 
 // categorical color palette for marking different tools
 // to enable easier visual distinction

--- a/app-ui/src/lib/traceview/traceview.tsx
+++ b/app-ui/src/lib/traceview/traceview.tsx
@@ -11,6 +11,7 @@ import {
   BsPencilFill,
   BsFileEarmarkBreak,
   BsDatabaseLock,
+  BsBracesAsterisk,
 } from "react-icons/bs";
 
 import { HighlightedJSON, Highlight, GroupedHighlight } from "./highlights";
@@ -786,13 +787,24 @@ function MessageHeader(props: {
  * Can be empty if the type should not have a descriptive name in the UI.
  */
 function annotationName(type: string) {
-  return type
+  if (type == "guardrails-error") {
+    return "guardrailing";
+  }
+  if (type == "analyzer-model") {
+    return "analysis";
+  }
+
+  return type;
 }
 
 function annotationIcon(type: string) {
   if (type === "user") {
-    return <BsPencilFill style={{ transform: 'scale(0.9)', transformOrigin: 'bottom' }}/>;
-  } 
+    return (
+      <BsPencilFill
+        style={{ transform: "scale(0.9)", transformOrigin: "bottom" }}
+      />
+    );
+  }
   if (type === "analyzer-model") {
     // other types do not have an explicit icon
     return <BsFileEarmarkBreak />;
@@ -834,10 +846,10 @@ function MessageHeaderAnnotationIndicator(props: {
     <>
       {annotationTypes.map((type, index) => {
         return (
-          <AnnotationCounterBadge 
-            key={index} 
-            count={type.count} 
-            type={type.type} 
+          <AnnotationCounterBadge
+            key={index}
+            count={type.count}
+            type={type.type}
             onClick={() => {
               if (type.address) {
                 reveal(type.address, "annotations", true, {
@@ -852,19 +864,30 @@ function MessageHeaderAnnotationIndicator(props: {
   );
 }
 
-// bedge component
-export function AnnotationCounterBadge(props: { count: number; type: string ; onClick?: () => void }) {
-
+// badge component
+export function AnnotationCounterBadge(props: {
+  count: number;
+  type: string;
+  onClick?: () => void;
+}) {
   const name = annotationName(props.type);
-  const tooltip = (props.count > 1 ? props.count + " ": "") + name + " annotation" + (props.count > 1 ? "s" : "");
+  const tooltip =
+    (props.count > 1 ? props.count + " " : "") +
+    name +
+    " annotation" +
+    (props.count > 1 ? "s" : "");
   return (
-    <span className={"annotation-indicator"} onClick={props.onClick} data-tooltip-id="highlight-tooltip" data-tooltip-content={tooltip}>
+    <span
+      className={"annotation-indicator"}
+      onClick={props.onClick}
+      data-tooltip-id="highlight-tooltip"
+      data-tooltip-content={tooltip}
+    >
       {annotationIcon(props.type)}
       {props.count > 1 ? <span className="count"> {props.count}</span> : null}
     </span>
   );
 }
-
 
 // categorical color palette for marking different tools
 // to enable easier visual distinction
@@ -933,6 +956,7 @@ function CompactView(props: { message: any }) {
 
   return (
     <span className="tool-call-badge" style={badge_string_style(f.name)}>
+      <BsBracesAsterisk />
       {compact}
     </span>
   );

--- a/app-ui/src/lib/traceview/traceview.tsx
+++ b/app-ui/src/lib/traceview/traceview.tsx
@@ -800,7 +800,7 @@ function annotationIcon(type: string) {
   if (type === "guardrails-error" || type === "analyzer") {
     return <BsDatabaseLock />;
   }
-  return "ciao"
+  return type;
 }
 
 /**

--- a/app-ui/src/pages/traces/Analyzer.tsx
+++ b/app-ui/src/pages/traces/Analyzer.tsx
@@ -7,6 +7,8 @@ import {
   BsStars,
   BsXCircle,
 } from "react-icons/bs";
+import { AnalyzerAnnotation } from ".././../lib/traceview/highlights";
+
 import "./Analyzer.scss";
 import logo from "../../assets/invariant.svg";
 import { reveal } from "../../lib/permalink-navigator";
@@ -65,60 +67,30 @@ export function useAnalyzer(): Analyzer {
 /**
  * Parses and sorts the issues from the analyzer output.
  */
-function useIssues(analyzerOutput: any, storedOutput?: any) {
+function useIssues(annotations?: AnalyzerAnnotation[]): AnalyzerAnnotation[] {
   const [issues, setIssues] = useState([] as any[]);
 
   // take analyzer output as list and sort by severity key
   useEffect(() => {
-    let output = analyzerOutput;
+    let issues = annotations || [] as AnalyzerAnnotation[];
 
-    // if there is no current (just generated) analyzer output, parse the stored output instead
-    if (!output) {
-      output = [];
-      try {
-        for (let i = 0; i < storedOutput.length; i++) {
-          if (storedOutput[i].source === "analyzer-model") {
-            try {
-              JSON.parse(storedOutput[i].content).forEach((item: any) => {
-                output.push(item);
-              });
-            } catch (e) {
-              console.error(
-                "Failed to parse stored analyzer output:",
-                storedOutput[i]
-              );
-            }
-            break;
-          }
-        }
-      } catch (e) {
-        console.error("Failed to parse analyzer output:", output);
-        output = null;
-      }
-    }
-
-    if (!output) {
+    if (!issues) {
       setIssues([]);
     }
-    let issues = output || [];
-
     // sort by severity
     issues.sort((a, b) => {
-      if (a.severity < b.severity) {
+      if (a.severity || 0 < (b.severity || 0)) {
         return 1;
-      } else if (a.severity > b.severity) {
+      } else if (a.severity || 0 > (b.severity || 0)) {
         return -1;
       }
       return 0;
     });
-
-    // if length > 1 and loading still in there, remove it
-    if (issues.length > 1 && issues[0].loading) {
-      issues = issues.slice(1);
-    }
+  
+    // if length > 1 and loading still in there, remove i
 
     setIssues(issues);
-  }, [analyzerOutput, storedOutput]);
+  }, [annotations]);
 
   return issues;
 }
@@ -168,7 +140,8 @@ function createAnalysis(
   setRunning: (running: boolean) => void,
   setError: (status: string | null) => void,
   setOutput: (output: any) => void,
-  setDebug?: (debug: any) => void
+  setDebug?: (debug: any) => void,
+  onAnnotationChange?: () => void,
 ): AbortController {
   const abortController = new AbortController();
 
@@ -185,6 +158,9 @@ function createAnalysis(
       }
       const url = `/api/v1/trace/${trace_id}/analysis`;
       setRunning(true);
+      setOutput((prev) => []);
+      if (onAnnotationChange)
+        onAnnotationChange()
       const response = await fetch(url, {
         method: "POST",
         body,
@@ -208,23 +184,22 @@ function createAnalysis(
       let event: any = null;
 
       for await (event of stream) {
+        if (event.data === "update" && onAnnotationChange){
+          onAnnotationChange()
+        }
         if (event.data) {
           try {
             const chunk_data = JSON.parse(event.data);
-            // handle debug messages separately
-            if (chunk_data.error) {
-              setRunning(false);
-              setError(chunk_data.error);
-              receivedError = true;
-              alert("Analysis Error: " + chunk_data.error);
-              return;
-            } else if (chunk_data.debug) {
+            if (chunk_data.content) {
+              if (onAnnotationChange)
+                onAnnotationChange()
+            }
+            if (chunk_data.debug) {
               if (setDebug) {
                 setDebug(chunk_data.debug);
               }
-            } else {
-              setOutput((prev) => [...(prev || []), chunk_data]);
             }
+
           } catch {
             setOutput((prev) => [
               ...(prev || []),
@@ -275,22 +250,19 @@ export function AnalyzerPreview(props: {
   open: boolean;
   setAnalyzerOpen: (open: boolean) => void;
   output: any;
-  storedOutput;
+  annotations;
   analyzer: Analyzer;
   running: boolean;
   onRunAnalyzer?: BroadcastEvent;
 }) {
-  const issues = useIssues(props.output, props.storedOutput);
+  const issues = useIssues(props.annotations);
 
-  const numIssues = issues.filter((i) => !i.loading).length;
+  const numIssues = issues.length;
 
-  const storedIsEmpty = !props.storedOutput?.filter((o) => o.length > 0).length;
-  const outputIsEmpty =
-    !props.output ||
-    (props.output.filter((o) => !o.loading).length === 0 && !props.running);
+  const storedIsEmpty = numIssues === 0;
 
   const notYetRun =
-    storedIsEmpty && outputIsEmpty && !props.running && numIssues === 0;
+    storedIsEmpty && !props.running && numIssues === 0;
 
   let content: React.ReactNode = null;
 
@@ -455,7 +427,7 @@ export function AnalyzerSidebar(props: {
   output: any;
   running: boolean;
   analyzer: Analyzer;
-  storedOutput;
+  annotations: AnalyzerAnnotation[];
   traceId: string;
   datasetId: string;
   username: string;
@@ -464,6 +436,7 @@ export function AnalyzerSidebar(props: {
   onDiscardAnalysisResult?: (output: any) => void;
   // passes onRun to parent component in callback
   onAnalyzeEvent?: BroadcastEvent;
+  onAnnotationChange?: () => void;
 }) {
   const [abortController, setAbortController] = React.useState(
     new AbortController()
@@ -472,12 +445,12 @@ export function AnalyzerSidebar(props: {
   const [settingsOpen, setSettingsOpen] = React.useState(false);
   const [status, setStatus] = useState("Ready");
 
-  const issues = useIssues(props.output, props.storedOutput);
-  const numIssues = issues.filter((i) => !i.loading).length;
+  const issues = useIssues(props.annotations);
+  const numIssues = issues.length;
 
   const userInfo = useUserInfo();
 
-  const storedIsEmpty = !props.storedOutput?.filter((o) => o.length > 0).length;
+  const storedIsEmpty = props.annotations.length === 0;
   const outputIsEmpty =
     !props.output ||
     (props.output.filter((o) => !o.loading).length === 0 && !props.running);
@@ -532,7 +505,8 @@ export function AnalyzerSidebar(props: {
         props.analyzer.setRunning,
         props.analyzer.setError,
         props.analyzer.setOutput,
-        props.analyzer.setDebug
+        props.analyzer.setDebug,
+        props.onAnnotationChange,
       );
       setAbortController(ctrl);
     } catch (error) {
@@ -568,7 +542,7 @@ export function AnalyzerSidebar(props: {
         {!notYetRun && !props.running && props.onDiscardAnalysisResult && (
           <button
             className="inline icon"
-            onClick={() => props.onDiscardAnalysisResult?.(props.storedOutput)}
+            onClick={() => props.onDiscardAnalysisResult?.(props.annotations)}
             data-tooltip-id="highlight-tooltip"
             data-tooltip-content="Discard Results"
           >
@@ -613,12 +587,7 @@ export function AnalyzerSidebar(props: {
       )}
       <div className="status">{status}</div>
       <div className="issues">
-        {issues.map((output, i) =>
-          output.loading ? (
-            props.running ? (
-              <Loading key="issues-loading" />
-            ) : null
-          ) : (
+        {issues.map((output, i) =>(
             <Issues
               key={props.traceId + "-" + "issue-" + i + "-" + output.content}
               issue={output}
@@ -698,7 +667,7 @@ function onMountConfigEditor(editor, monaco) {
 }
 
 export function Issues(props: {
-  issue: object & { severity: number; content: string; location: string };
+  issue: AnalyzerAnnotation;
 }) {
   // content: [abc] content
   let errorContent = "";
@@ -711,14 +680,14 @@ export function Issues(props: {
   }
 
   const first_location =
-    locations(props.issue.location).length > 0
-      ? locations(props.issue.location)[0]
+    locations(props.issue.address).length > 0
+      ? locations(props.issue.address)[0]
       : "";
 
   const [clickLocation, setClickLocation] = useState(first_location);
 
   const onNextLocation = () => {
-    const locs = locations(props.issue.location);
+    const locs = locations(props.issue.address);
     let idx = locs.indexOf(clickLocation);
     idx = (idx + 1) % locs.length;
     setClickLocation(locs[idx]);
@@ -741,7 +710,7 @@ export function Issues(props: {
         <b>[{errorContent}]</b> {content}
       </div>
       <div className="issue-header">
-        <Location location={props.issue.location} />
+        <Location location={props.issue.address} />
         <br />
         {typeof props.issue.severity === "number" && (
           <span className="severity">

--- a/app-ui/src/pages/traces/Analyzer.tsx
+++ b/app-ui/src/pages/traces/Analyzer.tsx
@@ -190,7 +190,6 @@ function createAnalysis(
         if (event.data) {
           try {
             const chunk_data = JSON.parse(event.data);
-            console.log(chunk_data);
             if (chunk_data.content) {
               if (onAnnotationChange)
                 onAnnotationChange()

--- a/app-ui/src/pages/traces/Analyzer.tsx
+++ b/app-ui/src/pages/traces/Analyzer.tsx
@@ -190,6 +190,7 @@ function createAnalysis(
         if (event.data) {
           try {
             const chunk_data = JSON.parse(event.data);
+            console.log(chunk_data);
             if (chunk_data.content) {
               if (onAnnotationChange)
                 onAnnotationChange()
@@ -197,6 +198,13 @@ function createAnalysis(
             if (chunk_data.debug) {
               if (setDebug) {
                 setDebug(chunk_data.debug);
+              }
+            }
+            if (chunk_data.error) {
+              receivedError = true;
+              if (setError) {
+                setError(chunk_data.error);
+                alert("Analysis Error: " + chunk_data.error);
               }
             }
 
@@ -250,7 +258,7 @@ export function AnalyzerPreview(props: {
   open: boolean;
   setAnalyzerOpen: (open: boolean) => void;
   output: any;
-  annotations;
+  annotations: AnalyzerAnnotation[];
   analyzer: Analyzer;
   running: boolean;
   onRunAnalyzer?: BroadcastEvent;
@@ -488,9 +496,6 @@ export function AnalyzerSidebar(props: {
     ]);
 
     const { config, endpoint, apikey } = clientAnalyzerConfig("single");
-    console.log("Analyzer options", config);
-    console.log("Analyzer endpoint", endpoint);
-    console.log("Analyzer apikey", apikey);
     if (!props.traceId) {
       console.error("analyzer: no trace ID provided");
       return;

--- a/app-ui/src/pages/traces/AnnotationAugmentedTraceView.jsx
+++ b/app-ui/src/pages/traces/AnnotationAugmentedTraceView.jsx
@@ -319,7 +319,6 @@ export function AnnotationAugmentedTraceView(props) {
         !props.hideAnnotations ? annotations : [],
         props.mappings
       );
-
     setHighlights({
       highlights: HighlightedJSON.from_entries(highlights),
       traceId: activeTraceId,
@@ -502,9 +501,7 @@ export function AnnotationAugmentedTraceView(props) {
                   setAnalyzerOpen={setAnalyzerOpen}
                   output={analyzer.output}
                   running={analyzer.running}
-                  storedOutput={top_level_annotations.filter(
-                    (a) => a.source == "analyzer-model"
-                  )}
+                  annotations={analyzer_annotations}
                   onRunAnalyzer={onRunAnalyzerEvent}
                 />
               )}
@@ -645,6 +642,12 @@ function AnnotationThread(props) {
   // let [annotations, annotationStatus, annotationsError, annotator] = props.annotations
   const [annotations, annotationStatus, annotationsError, annotator] =
     useRemoteResource(Annotations, props.traceId);
+  // filter out analyzer annotations
+  for (let address in annotations) {
+    annotations[address] = annotations[address].filter(
+      (a) => a.extra_metadata?.source !== "analyzer-model"
+    );
+  }
   const { onAnnotationCreate, onAnnotationDelete } = props;
   let threadAnnotations = (annotations || {})[props.address] || [];
 

--- a/app-ui/src/pages/traces/AnnotationAugmentedTraceView.jsx
+++ b/app-ui/src/pages/traces/AnnotationAugmentedTraceView.jsx
@@ -163,15 +163,24 @@ function useHighlightDecorator(
           let forAddressKey = address.replace(/\[\d+\]/g, (match) => {
             return "." + match.slice(1, -1);
           });
-          let n = highlights.highlights
+          let importantHighlights = highlights.highlights
             .for_path(forAddressKey)
-            .allHighlights().length;
-          if (n > 0) {
-            counts.push({
-              type: "highlight",
-              count: n,
-            });
+            .allHighlights();
+          const sources = importantHighlights.map(importantHighlight => 
+            importantHighlight[1].content?.source ?? "unknown"
+          );
+          let counts_map = new Map();
+          for (const source of sources) {
+             counts_map.set(source, (counts_map.get(source) || 0) + 1);
           }
+          
+          for (const [s, c] of counts_map.entries()) {
+             counts.push({
+                 type: s,
+                 count: c,
+             });
+          }
+          
         }
 
         // add user annotations
@@ -187,7 +196,7 @@ function useHighlightDecorator(
           });
           if (count > 0) {
             counts.push({
-              type: "human",
+              type: "user",
               count: count,
               address: first_match,
             });

--- a/app-ui/src/pages/traces/Traces.tsx
+++ b/app-ui/src/pages/traces/Traces.tsx
@@ -40,6 +40,7 @@ import { useTelemetry } from "../../utils/Telemetry.js";
 import { Time } from "../../components/Time";
 import { DeleteSnippetModal } from "../../lib/snippets";
 import { UserInfo } from "../../utils/UserInfo";
+import { AnnotationCounterBadge } from "../../lib/traceview/traceview";
 import TracePageNUX from "./NUX";
 import {
   DatasetNotFound,
@@ -369,7 +370,6 @@ function useTraces(
           }
           pathMap[path].indices.push(t.index);
         });
-        console.log("traceMap", traceMap);
         setTraces(new LightweightTraces(n, username, datasetname, traceMap));
         setHierarchyPaths(pathMap);
       })
@@ -380,7 +380,6 @@ function useTraces(
         }
       });
   };
-  console.log("fetching traces", traces);
   return [traces, hierarchyPaths, refresh];
 }
 
@@ -1777,7 +1776,6 @@ function TraceRowContents(props: { trace: Trace }) {
   }
 
   trace.annotations_by_source = trace.annotations_by_source ?? {}
-  console.log("annotations_by_source", trace.annotations_by_source);
   return (
     <>
       {name}
@@ -1787,19 +1785,13 @@ function TraceRowContents(props: { trace: Trace }) {
         <span className="warnings">{num_warnings} warnings</span>
       )}
       {(trace.annotations_by_source["user"] ?? 0) > 0 ? (
-        <span className={"badge user"} data-tooltip-id="highlight-tooltip" data-tooltip-content="User annotations">
-          {trace.annotations_by_source["user"]}
-        </span>
+        <AnnotationCounterBadge count={trace.annotations_by_source["user"]} type="user"/>
       ) : null}
       {(trace.annotations_by_source["analyzer-model"] ?? 0) > 0 ? (
-        <span className="badge analyzer-model" data-tooltip-id="highlight-tooltip" data-tooltip-content="Analyzer model annotations">
-          {trace.annotations_by_source["analyzer-model"]}
-        </span>
+        <AnnotationCounterBadge count={trace.annotations_by_source["analyzer-model"]} type="analyzer-model"/>
       ) : null}
       {(trace.annotations_by_source["guardrails-error"] ?? 0) > 0 ? (
-        <span className="badge guardrails-error" data-tooltip-id="highlight-tooltip" data-tooltip-content="Guardrails annotations">
-          {trace.annotations_by_source["guardrails-error"]}
-        </span>
+        <AnnotationCounterBadge count={trace.annotations_by_source["guardrails-error"]} type="guardrails-error"/>
       ) : null}
       {showLabel && (
         <div style={{width: "5px"}}></div>

--- a/app-ui/src/pages/traces/Traces.tsx
+++ b/app-ui/src/pages/traces/Traces.tsx
@@ -1766,7 +1766,12 @@ function TraceRowContents(props: { trace: Trace }) {
       </>
     );
   }
-
+  const {
+    viewOptions,
+    viewOptionsEditor,
+    showViewOptionsModal,
+    setShowViewOptionsModal,
+  } = useViewOptions();
   const showLabel = isTest || hasSuccessMetadata;
   let label = null;
   if (showLabel) {
@@ -1774,7 +1779,6 @@ function TraceRowContents(props: { trace: Trace }) {
     ? trace?.extra_metadata["invariant.num-failures"] 
     : trace?.extra_metadata["success"];
   }
-
   trace.annotations_by_source = trace.annotations_by_source ?? {}
   return (
     <>
@@ -1784,13 +1788,13 @@ function TraceRowContents(props: { trace: Trace }) {
       {hasWornings && (
         <span className="warnings">{num_warnings} warnings</span>
       )}
-      {(trace.annotations_by_source["user"] ?? 0) > 0 ? (
+      {(viewOptions.showUserBadges && (trace.annotations_by_source["user"] ?? 0) > 0) ? (
         <AnnotationCounterBadge count={trace.annotations_by_source["user"]} type="user"/>
       ) : null}
-      {(trace.annotations_by_source["analyzer-model"] ?? 0) > 0 ? (
+      {(viewOptions.showAnalyzerModelBedge && (trace.annotations_by_source["analyzer-model"] ?? 0) > 0) ? (
         <AnnotationCounterBadge count={trace.annotations_by_source["analyzer-model"]} type="analyzer-model"/>
       ) : null}
-      {(trace.annotations_by_source["guardrails-error"] ?? 0) > 0 ? (
+      {(viewOptions.showGuardrailsErrorBadge && (trace.annotations_by_source["guardrails-error"] ?? 0) > 0) ? (
         <AnnotationCounterBadge count={trace.annotations_by_source["guardrails-error"]} type="guardrails-error"/>
       ) : null}
       {showLabel && (

--- a/app-ui/src/pages/traces/Traces.tsx
+++ b/app-ui/src/pages/traces/Traces.tsx
@@ -1802,7 +1802,7 @@ function TraceRowContents(props: { trace: Trace }) {
           type="user"
         />
       ) : null}
-      {viewOptions.showAnalyzerModelBedge &&
+      {viewOptions.showAnalyzerModelBadge &&
       (trace.annotations_by_source["analyzer-model"] ?? 0) > 0 ? (
         <AnnotationCounterBadge
           count={trace.annotations_by_source["analyzer-model"]}

--- a/app-ui/src/pages/traces/ViewOptions.tsx
+++ b/app-ui/src/pages/traces/ViewOptions.tsx
@@ -9,7 +9,7 @@ export interface ViewOptions {
   autocollapseTestTraces: boolean;
   autocollapseAll: boolean;
   showUserBadges: boolean;
-  showAnalyzerModelBedge: boolean;
+  showAnalyzerModelBadge: boolean;
   showGuardrailsErrorBadge: boolean;
 }
 
@@ -35,7 +35,7 @@ export function useViewOptions(): {
     autocollapseTestTraces: false,
     autocollapseAll: false,
     showUserBadges: true,
-    showAnalyzerModelBedge: true,
+    showAnalyzerModelBadge: true,
     showGuardrailsErrorBadge: true,
   };
   try {
@@ -71,7 +71,7 @@ export function useViewOptions(): {
         autocollapseTestTraces: false,
         autocollapseAll: false,
         showUserBadges: true,
-        showAnalyzerModelBedge: true,
+        showAnalyzerModelBadge: true,
         showGuardrailsErrorBadge: true,
       };
       try {
@@ -177,11 +177,11 @@ export function useViewOptions(): {
           <input
             type="checkbox"
             name="viewOption"
-            checked={viewOptions.showAnalyzerModelBedge}
+            checked={viewOptions.showAnalyzerModelBadge}
             id="analyzer-model-badges"
             onChange={(e) =>
               setViewOptions({
-                showAnalyzerModelBedge: e.target.checked, // Use the actual checkbox state
+                showAnalyzerModelBadge: e.target.checked, // Use the actual checkbox state
               })
             }
           />

--- a/app-ui/src/pages/traces/ViewOptions.tsx
+++ b/app-ui/src/pages/traces/ViewOptions.tsx
@@ -3,10 +3,14 @@
  */
 
 import React from "react";
+import { AnnotationCounterBadge } from "../../lib/traceview/traceview";
 
 export interface ViewOptions {
   autocollapseTestTraces: boolean;
   autocollapseAll: boolean;
+  showUserBadges: boolean;
+  showAnalyzerModelBedge: boolean;
+  showGuardrailsErrorBadge: boolean;
 }
 
 export function useViewOptions(): {
@@ -27,6 +31,9 @@ export function useViewOptions(): {
   let options = {
     autocollapseTestTraces: false,
     autocollapseAll: false,
+    showUserBadges: true,
+    showAnalyzerModelBedge: true,
+    showGuardrailsErrorBadge: true,
   };
   try {
     options = JSON.parse(localStorageOptions || "{}");
@@ -48,7 +55,7 @@ export function useViewOptions(): {
       <h2>Trace Events</h2>
 
       <div>
-        <div>
+        <div className="radio-block">
           <input
             type="radio"
             name="viewOption"
@@ -69,7 +76,7 @@ export function useViewOptions(): {
             <p>All events are expanded by default.</p>
           </label>
         </div>
-        <div>
+        <div className="radio-block">
           <input
             type="radio"
             name="viewOption"
@@ -87,7 +94,7 @@ export function useViewOptions(): {
             <p>All events are collapsed by default.</p>
           </label>
         </div>
-        <div>
+        <div className="radio-block">
           <input
             type="radio"
             name="viewOption"
@@ -106,6 +113,57 @@ export function useViewOptions(): {
             Collapsed for Tests
             <p>Unit testing traces are collapsed by default.</p>
           </label>
+        </div>
+      </div>
+      <h2>Trace Badges</h2>
+      <h3>Choose which annotations bedges to display.</h3>
+      <div>
+        <div>
+          <input
+            type="checkbox"
+            name="viewOption"
+            checked={viewOptions.showUserBadges}
+            id="expanded"
+            onChange={(e) =>
+              setViewOptions({
+                showUserBadges: e.target.checked  // Use the actual checkbox state
+              })
+            }
+          />
+          <AnnotationCounterBadge count={1} type="user" />
+          <label>User annotations.</label>
+        </div>
+
+        <div>
+          <input
+            type="checkbox"
+            name="viewOption"
+            checked={viewOptions.showAnalyzerModelBedge}
+            id="autocollapse-all"
+            onChange={(e) =>
+              setViewOptions({
+                showAnalyzerModelBedge: e.target.checked  // Use the actual checkbox state
+              })
+            }
+          />
+          <AnnotationCounterBadge count={1} type="analyzer-model" />
+          <label>Analyzer Model annotations.</label>
+        </div>
+
+        <div className="badge-checkbox-group">
+          <input
+            type="checkbox"
+            name="viewOption"
+            checked={viewOptions.showGuardrailsErrorBadge}
+            id="autocollapse-test-traces"
+            onChange={(e) =>
+              setViewOptions({
+                showGuardrailsErrorBadge: e.target.checked  // Use the actual checkbox state
+              })
+            }
+          />
+          <AnnotationCounterBadge count={1} type="guardrails-error" />
+          <label>Guardrails annotations.</label>
         </div>
       </div>
     </div>

--- a/app-ui/src/styles/App.scss
+++ b/app-ui/src/styles/App.scss
@@ -747,6 +747,7 @@ button {
       font-size: 12pt;
       font-weight: bold;
       padding-top: 20pt;
+      margin-bottom: 0pt;
 
       p {
         margin: 0pt;
@@ -757,11 +758,13 @@ button {
         padding-bottom: 0pt;
       }
     }
+
     h3 {
       font-size: 10pt;
       margin-top: 0pt;
-      margin-bottom: 3pt;
+      margin-bottom: 5pt;
     }
+
     label {
       margin-left: 5pt;
       font-size: 12pt;
@@ -1326,11 +1329,11 @@ button.primary .shortcut {
           color: white;
 
           &.pass {
-            background-color: #1e883e;
+            background-color: #45d18b;
           }
 
           &.fail {
-            background-color: #ba2929;
+            background-color: #ff6678;
           }
         }
 

--- a/app-ui/src/styles/App.scss
+++ b/app-ui/src/styles/App.scss
@@ -1317,12 +1317,12 @@ button.primary .shortcut {
           display: inline-block;
           text-align: center;
           padding: 2pt 4pt;
-          font-size: 9pt;
+          font-size: 13pt;
           line-height: 16pt;
           color: white;
           border-radius: 2pt;
-          width: 24pt;
-          min-width: 24pt;
+          width: 12pt;
+          min-width: 12pt;
 
           &.pass {
             background-color: #1e883e;

--- a/app-ui/src/styles/App.scss
+++ b/app-ui/src/styles/App.scss
@@ -741,12 +741,12 @@ button {
   .options {
     display: block;
     max-width: 320pt;
+    border-top: 1pt solid rgb(234, 234, 234);
 
     h2 {
       font-size: 12pt;
       font-weight: bold;
-      border-top: 1pt solid rgb(234, 234, 234);
-      padding-top: 10pt;
+      padding-top: 20pt;
 
       p {
         margin: 0pt;
@@ -757,7 +757,11 @@ button {
         padding-bottom: 0pt;
       }
     }
-
+    h3 {
+      font-size: 10pt;
+      margin-top: 0pt;
+      margin-bottom: 3pt;
+    }
     label {
       margin-left: 5pt;
       font-size: 12pt;
@@ -778,7 +782,6 @@ button {
       margin-left: 17pt;
       color: $text-color;
       padding-bottom: 15pt;
-      border-bottom: 1pt solid rgb(234, 234, 234);
     }
 
     input {

--- a/app-ui/src/styles/App.scss
+++ b/app-ui/src/styles/App.scss
@@ -1314,15 +1314,13 @@ button.primary .shortcut {
         }
 
         .test-result {
-          display: inline-block;
+          height: 19pt;
+          width: 19pt;
+          line-height: 18pt;
+          font-size: 15pt;
           text-align: center;
-          padding: 2pt 4pt;
-          font-size: 13pt;
-          line-height: 16pt;
+          border-radius: 2.5pt;
           color: white;
-          border-radius: 2pt;
-          width: 12pt;
-          min-width: 12pt;
 
           &.pass {
             background-color: #1e883e;

--- a/tests/test-ui/test_filter_search.py
+++ b/tests/test-ui/test_filter_search.py
@@ -147,6 +147,6 @@ async def test_that_is_annotated_filter_works(context, url, data_abc, screenshot
         assert trace_result_badge.strip() == "1"
 
         # verify that the annotation indicator batch is shown on screen (.annotation-indicator.human)
-        annotation_indicator = page.locator(".annotation-indicator.human")
+        annotation_indicator = page.locator(".annotation-indicator")
         assert await annotation_indicator.count() == 1
         await screenshot(page)

--- a/tests/test-ui/test_filter_search.py
+++ b/tests/test-ui/test_filter_search.py
@@ -162,6 +162,7 @@ async def test_that_is_annotated_filter_works(context, url, data_abc, screenshot
             await screenshot(page)
             await page.reload()
             await page.wait_for_selector("div.explorer.panel.traceview", state="attached")
+            await page.wait_for_selector("#messages-0", state="visible")
             await screenshot(page)
 
         await click_view_badge()

--- a/tests/test-ui/test_filter_search.py
+++ b/tests/test-ui/test_filter_search.py
@@ -6,6 +6,7 @@ import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from test_basic import trace_shown_in_sidebar
+from playwright.async_api import expect
 from util import TemporaryExplorerDataset
 
 pytest_plugins = ("pytest_asyncio",)
@@ -143,10 +144,26 @@ async def test_that_is_annotated_filter_works(context, url, data_abc, screenshot
         trace_result = page.locator("li.trace.active").locator("a.active")
         trace_result_text = await trace_result.locator("span.name").text_content()
         assert trace_result_text.strip() == "Run 1"
-        trace_result_badge = await trace_result.locator("span.badge").text_content()
-        assert trace_result_badge.strip() == "1"
 
-        # verify that the annotation indicator batch is shown on screen (.annotation-indicator.human)
+        # verify that the annotation badge is shown on screen
         annotation_indicator = page.locator(".annotation-indicator")
         assert await annotation_indicator.count() == 1
+
+        await screenshot(page)
+
+        # Assert that it's there (exists and visible)
+        await page.click('button[data-tooltip-content="View Options"]')
+        user_annotation_checkbox = page.locator(
+            'div.options >> span.annotation-indicator[data-tooltip-content="user annotation"]'
+        ).locator('..').locator('input[type="checkbox"]')
+
+        # Change options to view user annotations on sidebar
+        await user_annotation_checkbox.click()
+        await screenshot(page)
+        await page.reload()
+        await screenshot(page)
+
+        # verify that the annotation indicator batch is shown on screen (.p.human), and on the sidebar
+        annotation_indicator = page.locator(".annotation-indicator")
+        assert await annotation_indicator.count() == 2
         await screenshot(page)

--- a/tests/test-ui/test_filter_search.py
+++ b/tests/test-ui/test_filter_search.py
@@ -1,6 +1,6 @@
 import os
 import sys
-
+import asyncio
 # add tests folder (parent) to sys.path
 import pytest
 
@@ -151,19 +151,23 @@ async def test_that_is_annotated_filter_works(context, url, data_abc, screenshot
 
         await screenshot(page)
 
-        # Assert that it's there (exists and visible)
-        await page.click('button[data-tooltip-content="View Options"]')
-        user_annotation_checkbox = page.locator(
-            'div.options >> span.annotation-indicator[data-tooltip-content="user annotation"]'
-        ).locator('..').locator('input[type="checkbox"]')
+        # Click the view badge option
+        async def click_view_badge():
+            await page.click('button[data-tooltip-content="View Options"]')
+            user_annotation_checkbox = page.locator(
+                'div.options >> span.annotation-indicator[data-tooltip-content="user annotation"]'
+            ).locator('..').locator('input[type="checkbox"]')
+            await user_annotation_checkbox.click()
+            await screenshot(page)
+            await page.reload()
+            await screenshot(page)
 
-        # Change options to view user annotations on sidebar
-        await user_annotation_checkbox.click()
-        await screenshot(page)
-        await page.reload()
-        await screenshot(page)
-
+        await click_view_badge()
         # verify that the annotation indicator batch is shown on screen (.p.human), and on the sidebar
         annotation_indicator = page.locator(".annotation-indicator")
+
         assert await annotation_indicator.count() == 2
         await screenshot(page)
+
+        await click_view_badge()
+        # Click the view badge option back

--- a/tests/test-ui/test_filter_search.py
+++ b/tests/test-ui/test_filter_search.py
@@ -17,6 +17,7 @@ async def test_navigate_with_search_query(context, url, data_code, screenshot):
     async with TemporaryExplorerDataset(url, context, data_code) as dataset:
         page = await context.new_page()
         await page.goto(f"{url}/u/developer/{dataset['name']}/t/1?query=foo")
+        await screenshot(page)
         await page.locator("div.filter-container").wait_for(state="attached")
         await screenshot(page)
 
@@ -160,12 +161,12 @@ async def test_that_is_annotated_filter_works(context, url, data_abc, screenshot
             await user_annotation_checkbox.click()
             await screenshot(page)
             await page.reload()
+            await page.wait_for_selector("div.explorer.panel.traceview", state="attached")
             await screenshot(page)
 
         await click_view_badge()
         # verify that the annotation indicator batch is shown on screen (.p.human), and on the sidebar
         annotation_indicator = page.locator(".annotation-indicator")
-
         assert await annotation_indicator.count() == 2
         await screenshot(page)
 


### PR DESCRIPTION
# Edits
* now analyzer annotations are not anymore batched. Each annotation is a record in the Annotation field.
* better labels on the left
* In the view-options menu, possiblity to enable or disable view of badges in the left sidebar


https://github.com/user-attachments/assets/1e935b05-9fd9-4dae-a755-e2fa53a69278

