### PR TITLE
Sort datasets by latest trace time instead of creation time

### DIFF
--- a/app-api/models/queries.py
+++ b/app-api/models/queries.py
@@ -651,13 +651,15 @@ def user_to_json(user: User):
     }
 
 
-def dataset_to_json(dataset, user=None, **kwargs):
+def dataset_to_json(dataset, user=None, latest_trace_time=None, **kwargs):
     out = {
         "id": dataset.id,
         "name": dataset.name,
         "extra_metadata": dataset.extra_metadata,
         "is_public": dataset.is_public,
         "user_id": dataset.user_id,
+        "time_created": dataset.time_created,
+        "latest_trace_time": latest_trace_time if latest_trace_time is not None else dataset.time_created
     }
     out = {**out, **kwargs}
     if user:

--- a/app-api/routes/dataset.py
+++ b/app-api/routes/dataset.py
@@ -233,14 +233,16 @@ def fetch_homepage_datasets(limit: Optional[int] = None) -> list[dict[str, Any]]
 
     with Session(db()) as session:
         datasets = (
-            session.query(Dataset, User)
+            session.query(Dataset, User, func.max(Trace.time_created).label('latest_trace_time'))
             .join(User, User.id == Dataset.user_id)
+            .outerjoin(Trace, Trace.dataset_id == Dataset.id)
             .filter(and_(Dataset.is_public, Dataset.id.in_(homepage_dataset_ids)))
-            .order_by(Dataset.time_created.desc())
+            .group_by(Dataset.id, User.id)
+            .order_by(func.coalesce(func.max(Trace.time_created), Dataset.time_created).desc())
             .limit(limit)
             .all()
         )
-    return [dataset_to_json(dataset, user) for dataset, user in datasets]
+    return [dataset_to_json(dataset, user, latest_trace_time=latest_trace_time) for dataset, user, latest_trace_time in datasets]
 
 
 @dataset.get("/list")
@@ -254,7 +256,14 @@ def list_datasets(
             # Use cached results for HOMEPAGE datasets
             return fetch_homepage_datasets(limit)
 
-        query = session.query(Dataset, User).join(User, User.id == Dataset.user_id)
+        # Base query joining Dataset with User and getting latest trace time
+        query = (
+            session.query(Dataset, User, func.max(Trace.time_created).label('latest_trace_time'))
+            .join(User, User.id == Dataset.user_id)
+            .outerjoin(Trace, Trace.dataset_id == Dataset.id)
+            .group_by(Dataset.id, User.id)
+        )
+        
         if kind == DatasetKind.PRIVATE:
             query = query.filter(Dataset.user_id == user_id)
         elif kind == DatasetKind.PUBLIC:
@@ -262,8 +271,11 @@ def list_datasets(
         elif kind == DatasetKind.ANY:
             query = query.filter(or_(Dataset.is_public, Dataset.user_id == user_id))
 
-        datasets = query.order_by(Dataset.time_created.desc()).limit(limit).all()
-        return [dataset_to_json(dataset, user) for dataset, user in datasets]
+        # Order by latest trace time if exists, otherwise by dataset creation time
+        datasets = query.order_by(
+            func.coalesce(func.max(Trace.time_created), Dataset.time_created).desc()
+        ).limit(limit).all()
+        return [dataset_to_json(dataset, user, latest_trace_time=latest_trace_time) for dataset, user, latest_trace_time in datasets]
 
 
 @dataset.get("/list/byuser/{user_name}")

--- a/app-ui/src/pages/home/Home.tsx
+++ b/app-ui/src/pages/home/Home.tsx
@@ -86,7 +86,7 @@ function Home() {
   // fetch datasets and snippets
   let [featuredDatasets, refreshFeaturedDatasets] = useDatasetList(
     "homepage",
-    8,
+    8
   );
 
   useEffect(() => {
@@ -119,7 +119,7 @@ function Home() {
 
   const [privateDatasets, refreshPrivateDatasets] = useDatasetList(
     "private",
-    8,
+    8
   );
 
   useEffect(() => {
@@ -232,7 +232,7 @@ function Home() {
                       "/u/" + event.user.username + "/" + event.details.name,
                     trace: "/trace/" + event.details.id,
                     annotation: "/trace/" + event.details?.trace?.id,
-                  }[event.type],
+                  }[event.type]
                 )
               }
               key={i}

--- a/app-ui/src/pages/user/DatasetList.tsx
+++ b/app-ui/src/pages/user/DatasetList.tsx
@@ -10,6 +10,7 @@ import {
   UploadDatasetModalContent,
 } from "../home/NewDataset";
 import { BsUpload } from "react-icons/bs";
+import { Time } from "../../components/Time";
 
 /**
  * Compact version of the dataset list (e.g. to use on the home page).
@@ -40,6 +41,11 @@ export function DatasetLinkList(props) {
                 </h3>
                 {dataset.description && (
                   <span className="description">{dataset.description}</span>
+                )}
+                {!dataset.description && dataset.latest_trace_time && (
+                  <span className="description">
+                    <Time>{dataset.latest_trace_time}</Time>
+                  </span>
                 )}
               </li>
             </Link>

--- a/app-ui/src/styles/App.scss
+++ b/app-ui/src/styles/App.scss
@@ -534,7 +534,7 @@ div.panel {
 
       span.description {
         opacity: 0.7;
-        margin-left: 20pt;
+        margin-left: 5pt;
         line-height: 30pt;
         font-size: 10pt;
 


### PR DESCRIPTION
- Modified dataset queries to join with Trace table and order by latest trace time
- Updated dataset_to_json to include latest_trace_time
- Added fallback to dataset creation time when no traces exist