### PR TITLE
Fix append messages API so that it accepts annotations for existing messages too.

### DIFF
--- a/app-api/routes/trace.py
+++ b/app-api/routes/trace.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import re
 import uuid
 from datetime import datetime, timezone
 from typing import Annotated, Dict, List
@@ -661,21 +660,13 @@ async def append_messages(
                 trace_response.content = combined_messages
                 flag_modified(trace_response, "content")
 
-                # The addresses in the annotations are relative to the new messages to append.
-                # When we append the new messages to the existing ones,
-                # we need to make sure that the
-                # addresses use the correct message offset.
+                # The annotations may not be for the new messages being appended only
+                # but also for the existing messages in the trace.
+                # This assumes that there are no concurrent calls to this endpoint when adding annotations.
+                # We intend to fix this long term by using message level ids (some sort of a uuid maybe?).
+                # We will not rely on messages indices then and this will be safe.
                 for annotation_data in annotations:
-                    # Update the address to point to the new messages
                     address = annotation_data.get("address")
-                    if address:
-                        # Update the message index after "messages."
-                        address = re.sub(
-                            r"^messages\.(\d+)",
-                            lambda m: f"messages.{int(m.group(1)) + exising_messages_count}",
-                            address,
-                        )
-
                     new_annotation = Annotation(
                         trace_id=trace_id,
                         user_id=user_id,


### PR DESCRIPTION
We don't need to update addresses on the annotations for the new messages. This will not work correctly with concurrent append messages calls when we also add annotations - we intend to fix that in the future by using some sort of a message level id instead of index to connect an annotation to a message.

This will work with the current MCP gateway stdio implementation since guardrail checking service will give us annotations for both the older messages in the trace and the newer messages with the correct addresses. There will not be concurrent calls to the same trace in this case.