### PR TITLE
change download-analyzer file extension from json to jsonl

### DIFF
--- a/app-api/routes/dataset/traces.py
+++ b/app-api/routes/dataset/traces.py
@@ -245,7 +245,7 @@ async def download_traces_as_analyzer_input(
 
         return StreamingResponse(
             content=stream_analyzer_input(),
-            media_type="application/jsonl",
+            media_type="application/json",
             headers={
                 "Content-Disposition": f"attachment; filename={dataset.name}_analyzer_input.jsonl"
             },

--- a/app-api/routes/dataset/traces.py
+++ b/app-api/routes/dataset/traces.py
@@ -245,9 +245,9 @@ async def download_traces_as_analyzer_input(
 
         return StreamingResponse(
             content=stream_analyzer_input(),
-            media_type="application/json",
+            media_type="application/jsonl",
             headers={
-                "Content-Disposition": f"attachment; filename={dataset.name}_analyzer_input.json"
+                "Content-Disposition": f"attachment; filename={dataset.name}_analyzer_input.jsonl"
             },
         )
 


### PR DESCRIPTION
The downloaded files should be jsonl because the analyzer model requires datasets to be jsonl files.